### PR TITLE
Use separate stop for index worker in gcs

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -86,6 +86,8 @@ jobs:
         release_name: Release ${{ github.ref }}
         body: |
           Changes in this Release
+           - Fixed bug where index was not completely updated with all put blocks
+           - Fixed performance issue when storing many blocks in one session
         draft: false
         prerelease: false
     - name: Download Linux artifacts

--- a/longtaillib/golongtail.go
+++ b/longtaillib/golongtail.go
@@ -1257,6 +1257,18 @@ func MergeContentIndex(
 	return Longtail_ContentIndex{cContentIndex: mergedContentIndex}, nil
 }
 
+// AddContentIndex ...
+func AddContentIndex(
+	localContentIndex Longtail_ContentIndex,
+	remoteContentIndex Longtail_ContentIndex) (Longtail_ContentIndex, error) {
+	var mergedContentIndex *C.struct_Longtail_ContentIndex
+	errno := C.Longtail_AddContentIndex(localContentIndex.cContentIndex, remoteContentIndex.cContentIndex, &mergedContentIndex)
+	if errno != 0 {
+		return Longtail_ContentIndex{cContentIndex: nil}, fmt.Errorf("AddContentIndex: C.Longtail_AddContentIndex() failed with error %d", errno)
+	}
+	return Longtail_ContentIndex{cContentIndex: mergedContentIndex}, nil
+}
+
 // WriteVersion ...
 func WriteVersion(
 	contentBlockStoreAPI Longtail_BlockStoreAPI,


### PR DESCRIPTION
we need all put block to finish before stopping index worker.
Use faster AddContentIndex for index worker, we use merge when updating remote index.