### PR TITLE
Use proper naming of blocks in GCS store.

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -86,8 +86,8 @@ jobs:
         release_name: Release ${{ github.ref }}
         body: |
           Changes in this Release
-           - Updated to longtail v0.0.17
-           - *Breaking Compatability Change* VersionIndex files are incompatible with v0.0.16
+           - Updated to longtail v0.0.19
+           - *BREAKING CHANGE* Change naming of stored block in GCS
         draft: false
         prerelease: false
     - name: Download Linux artifacts

--- a/longtailstorelib/gcsstore.go
+++ b/longtailstorelib/gcsstore.go
@@ -539,9 +539,9 @@ func NewGCSBlockStore(u *url.URL, maxBlockSize uint32, maxChunksPerBlock uint32,
 }
 
 func getBlockPath(basePath string, blockHash uint64) string {
-	sID := fmt.Sprintf("%x", blockHash)
-	dir := filepath.Join(basePath, sID[0:4])
-	name := filepath.Join(dir, sID) + ".lsb"
+	fileName := fmt.Sprintf("0x%016x.lsb", blockHash)
+	dir := filepath.Join(basePath, fileName[2:4])
+	name := filepath.Join(dir, fileName)
 	name = strings.Replace(name, "\\", "/", -1)
 	return name
 }

--- a/longtailstorelib/gcsstore.go
+++ b/longtailstorelib/gcsstore.go
@@ -540,7 +540,7 @@ func NewGCSBlockStore(u *url.URL, maxBlockSize uint32, maxChunksPerBlock uint32,
 
 func getBlockPath(basePath string, blockHash uint64) string {
 	fileName := fmt.Sprintf("0x%016x.lsb", blockHash)
-	dir := filepath.Join(basePath, fileName[2:4])
+	dir := filepath.Join(basePath, fileName[2:6])
 	name := filepath.Join(dir, fileName)
 	name = strings.Replace(name, "\\", "/", -1)
 	return name


### PR DESCRIPTION
Chunks stored in GCS now uses the format 0x016%x - padded with zeros to 16 characters.
Updated release notes