### PR TITLE
Feature/path filter regex

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -87,8 +87,8 @@ jobs:
         body: |
           Changes in this Release
            - Bumped longtail to v0.0.22
-           - Added `--input-include-filter-regex` option to filter source/target folders
-           - Added `--input-exclude-filter-regex` option to filter source/target folders
+           - Added `--include-filter-regex` option to filter source/target folders
+           - Added `--exclude-filter-regex` option to filter source/target folders
         draft: false
         prerelease: false
     - name: Download Linux artifacts

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -86,9 +86,9 @@ jobs:
         release_name: Release ${{ github.ref }}
         body: |
           Changes in this Release
-           - Added go.mod for longtaillib module
-           - Bumped longtail to v0.0.21
-           - Bumped default block size to 8Mb
+           - Bumped longtail to v0.0.22
+           - Added `--input-include-filter-regex` option to filter source/target folders
+           - Added `--input-exclude-filter-regex` option to filter source/target folders
         draft: false
         prerelease: false
     - name: Download Linux artifacts

--- a/cmd/longtail/main.go
+++ b/cmd/longtail/main.go
@@ -288,23 +288,23 @@ func upSyncVersion(
 	maxChunksPerBlock uint32,
 	compressionAlgorithm *string,
 	hashAlgorithm *string,
-	inputIncludeFilterRegEx *string,
-	inputExcludeFilterRegEx *string,
+	includeFilterRegEx *string,
+	excludeFilterRegEx *string,
 	outFinalStats *longtaillib.BlockStoreStats) error {
 
 	var pathFilter longtaillib.Longtail_PathFilterAPI
 
-	if inputIncludeFilterRegEx != nil || inputExcludeFilterRegEx != nil {
+	if includeFilterRegEx != nil || excludeFilterRegEx != nil {
 		regexPathFilter := &regexPathFilter{}
-		if inputIncludeFilterRegEx != nil {
-			compiledIncludeRegexes, err := splitRegexes(*inputIncludeFilterRegEx)
+		if includeFilterRegEx != nil {
+			compiledIncludeRegexes, err := splitRegexes(*includeFilterRegEx)
 			if err != nil {
 				return err
 			}
 			regexPathFilter.compiledIncludeRegexes = compiledIncludeRegexes
 		}
-		if inputExcludeFilterRegEx != nil {
-			compiledExcludeRegexes, err := splitRegexes(*inputExcludeFilterRegEx)
+		if excludeFilterRegEx != nil {
+			compiledExcludeRegexes, err := splitRegexes(*excludeFilterRegEx)
 			if err != nil {
 				return err
 			}
@@ -459,23 +459,23 @@ func downSyncVersion(
 	targetIndexPath *string,
 	localCachePath string,
 	retainPermissions bool,
-	inputIncludeFilterRegEx *string,
-	inputExcludeFilterRegEx *string,
+	includeFilterRegEx *string,
+	excludeFilterRegEx *string,
 	outFinalStats *longtaillib.BlockStoreStats) error {
 
 	var pathFilter longtaillib.Longtail_PathFilterAPI
 
-	if inputIncludeFilterRegEx != nil || inputExcludeFilterRegEx != nil {
+	if includeFilterRegEx != nil || excludeFilterRegEx != nil {
 		regexPathFilter := &regexPathFilter{}
-		if inputIncludeFilterRegEx != nil {
-			compiledIncludeRegexes, err := splitRegexes(*inputIncludeFilterRegEx)
+		if includeFilterRegEx != nil {
+			compiledIncludeRegexes, err := splitRegexes(*includeFilterRegEx)
 			if err != nil {
 				return err
 			}
 			regexPathFilter.compiledIncludeRegexes = compiledIncludeRegexes
 		}
-		if inputExcludeFilterRegEx != nil {
-			compiledExcludeRegexes, err := splitRegexes(*inputExcludeFilterRegEx)
+		if excludeFilterRegEx != nil {
+			compiledExcludeRegexes, err := splitRegexes(*excludeFilterRegEx)
 			if err != nil {
 				return err
 			}
@@ -637,11 +637,11 @@ func downSyncVersion(
 }
 
 var (
-	logLevel                = kingpin.Flag("log-level", "Log level").Default("warn").Enum("debug", "info", "warn", "error")
-	storageURI              = kingpin.Flag("storage-uri", "Storage URI (only GCS bucket URI supported)").Required().String()
-	showStats               = kingpin.Flag("show-stats", "Output brief stats summary").Bool()
-	inputIncludeFilterRegEx = kingpin.Flag("input-include-filter-regex", "Optionl regex to use to filter input files in source folder to include. Separate regexes with **").String()
-	inputExcludeFilterRegEx = kingpin.Flag("input-exclude-filter-regex", "Optionl regex to use to filter input files in source folder to exclude. Separate regexes with **").String()
+	logLevel           = kingpin.Flag("log-level", "Log level").Default("warn").Enum("debug", "info", "warn", "error")
+	storageURI         = kingpin.Flag("storage-uri", "Storage URI (only GCS bucket URI supported)").Required().String()
+	showStats          = kingpin.Flag("show-stats", "Output brief stats summary").Bool()
+	includeFilterRegEx = kingpin.Flag("include-filter-regex", "Optional include regex filter for assets in --source-path on upsync and --target-path on downsync. Separate regexes with **").String()
+	excludeFilterRegEx = kingpin.Flag("exclude-filter-regex", "Optional exclude regex filter for assets in --source-path on upsync and --target-path on downsync. Separate regexes with **").String()
 
 	commandUpSync = kingpin.Command("upsync", "Upload a folder")
 	hashing       = commandUpSync.Flag("hash-algorithm", "Hashing algorithm: blake2, blake3, meow").
@@ -707,8 +707,8 @@ func main() {
 			*maxChunksPerBlock,
 			compression,
 			hashing,
-			inputIncludeFilterRegEx,
-			inputExcludeFilterRegEx,
+			includeFilterRegEx,
+			excludeFilterRegEx,
 			&stats)
 		if err != nil {
 			log.Fatal(err)
@@ -721,8 +721,8 @@ func main() {
 			targetIndexPath,
 			*localCachePath,
 			!(*noRetainPermissions),
-			inputIncludeFilterRegEx,
-			inputExcludeFilterRegEx,
+			includeFilterRegEx,
+			excludeFilterRegEx,
 			&stats)
 		if err != nil {
 			log.Fatal(err)

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	cloud.google.com/go/storage v1.6.0
-	github.com/DanEngelbrecht/golongtail/longtaillib v0.0.22 // indirect
+	github.com/DanEngelbrecht/golongtail/longtaillib v0.0.22
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
 	github.com/pkg/errors v0.9.1

--- a/longtaillib/golongtail.h
+++ b/longtaillib/golongtail.h
@@ -70,7 +70,7 @@ struct PathFilterAPIProxy
 
 static void* PathFilterAPIProxy_GetContext(void* api) { return ((struct PathFilterAPIProxy*)api)->m_Context; }
 void PathFilterAPIProxy_Dispose(struct Longtail_API* api);
-int PathFilterAPIProxy_Include(struct Longtail_PathFilterAPI* path_filter_api, char* root_path, char* asset_folder, char* asset_name, int is_dir, uint64_t size, uint16_t permissions);
+int PathFilterAPIProxy_Include(struct Longtail_PathFilterAPI* path_filter_api, char* root_path, char* asset_path, char* asset_name, int is_dir, uint64_t size, uint16_t permissions);
 
 static struct Longtail_PathFilterAPI* CreatePathFilterProxyAPI(void* context)
 {

--- a/longtaillib/longtail/lib/filestorage/longtail_filestorage.c
+++ b/longtaillib/longtail/lib/filestorage/longtail_filestorage.c
@@ -278,7 +278,7 @@ static int FSStorageAPI_StartFind(struct Longtail_StorageAPI* storage_api, const
     int err = Longtail_StartFind((HLongtail_FSIterator)iterator, tmp_path);
     if (err)
     {
-        LONGTAIL_LOG(LONGTAIL_LOG_LEVEL_ERROR, "FSStorageAPI_StartFind(%p, %s, %p) failed with %d",
+        LONGTAIL_LOG(err == ENOENT ? LONGTAIL_LOG_LEVEL_WARNING : LONGTAIL_LOG_LEVEL_ERROR, "FSStorageAPI_StartFind(%p, %s, %p) failed with %d",
             storage_api, path, out_iterator,
             err)
 		Longtail_Free(iterator);

--- a/longtaillib/longtail/src/longtail.h
+++ b/longtaillib/longtail/src/longtail.h
@@ -72,7 +72,14 @@ LONGTAIL_EXPORT int Longtail_CancelAPI_IsCancelled(struct Longtail_CancelAPI* ca
 
 struct Longtail_PathFilterAPI;
 
-typedef int (*Longtail_PathFilter_IncludeFunc)(struct Longtail_PathFilterAPI* path_filter_api, const char* root_path, const char* asset_folder, const char* asset_name, int is_dir, uint64_t size, uint16_t permissions);
+typedef int (*Longtail_PathFilter_IncludeFunc)(
+    struct Longtail_PathFilterAPI* path_filter_api,
+    const char* root_path,
+    const char* asset_path,
+    const char* asset_name,
+    int is_dir,
+    uint64_t size,
+    uint16_t permissions);
 
 struct Longtail_PathFilterAPI
 {
@@ -87,7 +94,7 @@ LONGTAIL_EXPORT struct Longtail_PathFilterAPI* Longtail_MakePathFilterAPI(
     Longtail_DisposeFunc dispose_func,
     Longtail_PathFilter_IncludeFunc include_filter_func);
 
-LONGTAIL_EXPORT int Longtail_PathFilter_Include(struct Longtail_PathFilterAPI* path_filter_api, const char* root_path, const char* asset_folder, const char* asset_name, int is_dir, uint64_t size, uint16_t permissions);
+LONGTAIL_EXPORT int Longtail_PathFilter_Include(struct Longtail_PathFilterAPI* path_filter_api, const char* root_path, const char* asset_path, const char* asset_name, int is_dir, uint64_t size, uint16_t permissions);
 
 ////////////// Longtail_HashAPI
 

--- a/longtaillib/longtaillib.go
+++ b/longtaillib/longtaillib.go
@@ -50,7 +50,7 @@ type ProgressAPI interface {
 	OnProgress(totalCount uint32, doneCount uint32)
 }
 type PathFilterAPI interface {
-	Include(rootPath string, assetFolder string, assetName string, isDir bool, size uint64, permissions uint16) bool
+	Include(rootPath string, assetPath string, assetName string, isDir bool, size uint64, permissions uint16) bool
 }
 
 type AsyncPutStoredBlockAPI interface {
@@ -1118,11 +1118,11 @@ func CreatePathFilterAPI(pathFilter PathFilterAPI) Longtail_PathFilterAPI {
 }
 
 //export PathFilterAPIProxy_Include
-func PathFilterAPIProxy_Include(path_filter_api *C.struct_Longtail_PathFilterAPI, root_path *C.char, asset_folder *C.char, asset_name *C.char, is_dir C.int, size C.uint64_t, permissions C.uint16_t) C.int {
+func PathFilterAPIProxy_Include(path_filter_api *C.struct_Longtail_PathFilterAPI, root_path *C.char, asset_path *C.char, asset_name *C.char, is_dir C.int, size C.uint64_t, permissions C.uint16_t) C.int {
 	context := C.PathFilterAPIProxy_GetContext(unsafe.Pointer(path_filter_api))
 	pathFilter := RestorePointer(context).(PathFilterAPI)
 	isDir := is_dir != 0
-	if pathFilter.Include(C.GoString(root_path), C.GoString(asset_folder), C.GoString(asset_name), isDir, uint64(size), uint16(permissions)) {
+	if pathFilter.Include(C.GoString(root_path), C.GoString(asset_path), C.GoString(asset_name), isDir, uint64(size), uint16(permissions)) {
 		return 1
 	}
 	return 0


### PR DESCRIPTION
Added path filtering options for upsync and downsync
 - `--include-filter-regex`
 - `--exclude-filter-regex`

Regexes are straight golang regexes and will not automatically do case insensitive searches.
Regex options can contain multiple regex expressions, each separated by two asterisks `**`.