### PR TITLE
If gcs store index does not exists, reconstruct from blocks.

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -86,8 +86,7 @@ jobs:
         release_name: Release ${{ github.ref }}
         body: |
           Changes in this Release
-           - *UPDATED* Update to longtail v0.0.42.
-           - *FIXED* downsync: Use target chunk size from source version index when indexing target folder
+           - *ADDED* GCS block store can now reconstruct a missing store index from blocks
         draft: false
         prerelease: false
     - name: Download Linux artifacts

--- a/longtaillib/longtaillib.go
+++ b/longtaillib/longtaillib.go
@@ -752,6 +752,10 @@ func (blockIndex *Longtail_BlockIndex) GetChunkSizes() []uint32 {
 	return carray2slice32(blockIndex.cBlockIndex.m_ChunkSizes, size)
 }
 
+func (blockIndex *Longtail_BlockIndex) IsValid() bool {
+	return blockIndex.cBlockIndex != nil
+}
+
 func (storedBlock *Longtail_StoredBlock) GetBlockIndex() Longtail_BlockIndex {
 	return Longtail_BlockIndex{cBlockIndex: storedBlock.cStoredBlock.m_BlockIndex}
 }


### PR DESCRIPTION
This can be a slow as all blocks needs to be read from the remote store.