### PR TITLE
Fix hang on get index

### DIFF
--- a/cmd/longtail/main.go
+++ b/cmd/longtail/main.go
@@ -438,6 +438,10 @@ func upSyncVersion(
 	defer versionContentIndex.Dispose()
 
 	existingRemoteContentIndex, errno := retargetContentIndexSync(indexStore, versionContentIndex)
+	if errno != 0 {
+		return fmt.Errorf("upSyncVersion: longtaillib.retargetContentIndexSync() failed with %s", longtaillib.ErrNoToDescription(errno))
+	}
+
 	defer existingRemoteContentIndex.Dispose()
 
 	versionMissingContentIndex, errno := longtaillib.CreateMissingContent(


### PR DESCRIPTION
If index worker fails startup, go into "fail mode" which stops respond with error on requests