### PR TITLE
Fix/longtail api leak

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -116,7 +116,8 @@ jobs:
         release_name: Release ${{ github.ref }}
         body: |
           Changes in this Release
-          - *ADDED* `stats` command for showing fragmentation and block usage for a version index
+          - **ADDED** `stats` command for showing fragmentation and block usage for a version index
+          - **FIX** Fixed resource leak of async completion API
         draft: false
         prerelease: false
     - name: Download Linux artifacts

--- a/cmd/longtail/main.go
+++ b/cmd/longtail/main.go
@@ -1724,6 +1724,7 @@ func stats(
 
 	blockChunkCount := uint64(0)
 
+	progress := &progressData{task: "Fetching blocks"}
 	blockHashes := existingContentIndex.GetBlockHashes()
 	maxBatchSize := runtime.NumCPU()
 	for i := 0; i < len(blockHashes); {
@@ -1753,6 +1754,7 @@ func stats(
 		}
 
 		i += batchSize
+		progress.OnProgress(uint32(len(blockHashes)), uint32(i))
 	}
 
 	blockUsage := uint32(100)


### PR DESCRIPTION
- **ADDED** `stats` command for showing fragmentation and block usage for a version index
- **FIX** Fixed resource leak of async completion API