### PR TITLE
Proper close/exit of workers in remotestore

### DIFF
--- a/longtailstorelib/gcsstore.go
+++ b/longtailstorelib/gcsstore.go
@@ -145,11 +145,11 @@ func (blobObject *gcsBlobObject) Exists() (bool, error) {
 }
 
 func (blobObject *gcsBlobObject) Write(data []byte) (bool, error) {
-	var writer storage.Writer
+	var writer *storage.Writer
 	if blobObject.writeCondition == nil {
-		writer := blobObject.objHandle.NewWriter(blobObject.ctx)
+		writer = blobObject.objHandle.NewWriter(blobObject.ctx)
 	} else {
-		writer := blobObject.objHandle.If(*blobObject.writeCondition).NewWriter(blobObject.ctx)
+		writer = blobObject.objHandle.If(*blobObject.writeCondition).NewWriter(blobObject.ctx)
 	}
 
 	_, err := writer.Write(data)
@@ -163,7 +163,7 @@ func (blobObject *gcsBlobObject) Write(data []byte) (bool, error) {
 		return false, err2
 	}
 
-	_, err := blobObject.objHandle.Update(blobObject.ctx, storage.ObjectAttrsToUpdate{ContentType: "application/octet-stream"})
+	_, err = blobObject.objHandle.Update(blobObject.ctx, storage.ObjectAttrsToUpdate{ContentType: "application/octet-stream"})
 	if err != nil {
 		return true, err
 	}

--- a/longtailstorelib/gcsstore.go
+++ b/longtailstorelib/gcsstore.go
@@ -32,6 +32,11 @@ type gcsBlobObject struct {
 	client         *gcsBlobClient
 }
 
+const (
+	// If the meta generation changes between our lock and write/close we get a gcs error with code 412
+	writeConditionFailed = 412
+)
+
 // NewGCSBlobStore ...
 func NewGCSBlobStore(u *url.URL) (BlobStore, error) {
 	if u.Scheme != "gs" {
@@ -121,16 +126,15 @@ func (blobObject *gcsBlobObject) Read() ([]byte, error) {
 
 func (blobObject *gcsBlobObject) LockWriteVersion() (bool, error) {
 	objAttrs, err := blobObject.objHandle.Attrs(blobObject.ctx)
-	if err == nil {
-		blobObject.writeCondition = &storage.Conditions{MetagenerationMatch: objAttrs.Metageneration, DoesNotExist: false}
-
-		return true, nil
-	}
 	if err == storage.ErrObjectNotExist {
 		blobObject.writeCondition = &storage.Conditions{DoesNotExist: true}
 		return false, nil
+	} else if err != nil {
+		return false, err
 	}
-	return false, err
+
+	blobObject.writeCondition = &storage.Conditions{MetagenerationMatch: objAttrs.Metageneration, DoesNotExist: false}
+	return true, nil
 }
 
 func (blobObject *gcsBlobObject) Exists() (bool, error) {
@@ -157,7 +161,7 @@ func (blobObject *gcsBlobObject) Write(data []byte) (bool, error) {
 	if err != nil {
 		return false, errors.Wrap(err, blobObject.path)
 	}
-	if e, ok := err2.(*googleapi.Error); ok && e.Code == 412 {
+	if e, ok := err2.(*googleapi.Error); ok && e.Code == writeConditionFailed {
 		return false, nil
 	} else if err2 != nil {
 		return false, err2

--- a/longtailstorelib/remotestore.go
+++ b/longtailstorelib/remotestore.go
@@ -987,18 +987,7 @@ func contentIndexWorker(
 	if accessType == ReadOnly {
 		return nil
 	}
-	/*
-		for {
-			select {
-			case blockIndexMsg, isChannelOpen := <-blockIndexMessages:
-				if !isChannelOpen {
-					// ?? Does break break out of the for loop or just this select statement?
-					break
-				}
-				addedBlockIndexes = append(addedBlockIndexes, blockIndexMsg.blockIndex)
-			}
-		}
-	*/
+
 	if len(addedBlockIndexes) > 0 {
 		updatedStoreIndex, err := updateStoreIndex(storeIndex, addedBlockIndexes)
 		if err != nil {


### PR DESCRIPTION
- Use close() on channels to detect end of messages
- Clean up gcsstore.go