### PR TITLE
Fix/gcs block store write lock

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -116,7 +116,7 @@ jobs:
         release_name: Release ${{ github.ref }}
         body: |
           Changes in this Release
-          - **FIXED** Use Generation when locking file versions in GCS instead of Metageneration
+          - **FIXED** Use GenerationMatch instead of MetagenerationMatch in GCS to fix store index from loosing content
         draft: false
         prerelease: false
     - name: Download Linux artifacts

--- a/longtailstorelib/fileBlobStore_test.go
+++ b/longtailstorelib/fileBlobStore_test.go
@@ -8,7 +8,8 @@ import (
 
 func TestFSBlobStore(t *testing.T) {
 	// This test uses hardcoded paths and is disabled
-	return
+	t.Skip()
+
 	blobStore, err := NewFSBlobStore("C:\\Temp\\fsblobstore")
 	if err != nil {
 		t.Errorf("NewFSBlobStore() err == %q", err)

--- a/longtailstorelib/gcsBlobStore_test.go
+++ b/longtailstorelib/gcsBlobStore_test.go
@@ -14,8 +14,9 @@ import (
 )
 
 func TestGCSBlobStore(t *testing.T) {
-	// This test uses hardcoded paths and is disabled
-	return
+	// This test uses hardcoded paths in gcs and is disabled
+	t.Skip()
+
 	u, err := url.Parse("gs://longtail-storage/test-storage/store")
 	if err != nil {
 		t.Errorf("url.Parse() err == %q", err)
@@ -42,8 +43,9 @@ func TestGCSBlobStore(t *testing.T) {
 }
 
 func TestGCSBlobStoreVersioning(t *testing.T) {
-	// This test uses hardcoded paths and is disabled
-	return
+	// This test uses hardcoded paths in gcs and is disabled
+	t.Skip()
+
 	u, err := url.Parse("gs://longtail-storage/test-storage/store")
 	if err != nil {
 		t.Errorf("url.Parse() err == %q", err)
@@ -147,8 +149,9 @@ func writeANumberWithRetry(number int, blobStore BlobStore) error {
 }
 
 func TestGCSBlobStoreVersioningStressTest(t *testing.T) {
-	// This test uses hardcoded paths and is disabled
-	return
+	// This test uses hardcoded paths in gcs and is disabled
+	t.Skip()
+
 	u, err := url.Parse("gs://longtail-storage/test-storage/store")
 	if err != nil {
 		t.Errorf("url.Parse() err == %q", err)

--- a/longtailstorelib/gcsBlobStore_test.go
+++ b/longtailstorelib/gcsBlobStore_test.go
@@ -1,8 +1,14 @@
 package longtailstorelib
 
 import (
+	"fmt"
+	"log"
 	"net/url"
+	"sort"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"golang.org/x/net/context"
 )
@@ -97,5 +103,98 @@ func TestGCSBlobStoreVersioning(t *testing.T) {
 	err = object.Delete()
 	if err != nil {
 		t.Errorf("object.Delete() err == %q", err)
+	}
+}
+
+func writeANumberWithRetry(number int, blobStore BlobStore) error {
+	client, err := blobStore.NewClient(context.Background())
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+	object, err := client.NewObject("test.txt")
+	if err != nil {
+		return err
+	}
+	for {
+		exists, err := object.LockWriteVersion()
+		if err != nil {
+			return err
+		}
+		var sliceData []string
+		if exists {
+			data, err := object.Read()
+			if err != nil {
+				return err
+			}
+			time.Sleep(300 * time.Millisecond)
+			sliceData = strings.Split(string(data), "\n")
+		}
+		sliceData = append(sliceData, fmt.Sprintf("%05d", number))
+		sort.Strings(sliceData)
+		newData := strings.Join(sliceData, "\n")
+
+		ok, err := object.Write([]byte(newData))
+		if err != nil {
+			return err
+		}
+		if ok {
+			log.Printf("Wrote %d\n", number)
+			return nil
+		}
+		log.Printf("Retrying %d\n", number)
+	}
+}
+
+func TestGCSBlobStoreVersioningStressTest(t *testing.T) {
+	// This test uses hardcoded paths and is disabled
+	return
+	u, err := url.Parse("gs://longtail-storage/test-storage/store")
+	if err != nil {
+		t.Errorf("url.Parse() err == %q", err)
+	}
+	blobStore, err := NewGCSBlobStore(u)
+	if err != nil {
+		t.Errorf("NewGCSBlobStore() err == %q", err)
+	}
+
+	var wg sync.WaitGroup
+
+	for i := 0; i < 10; i++ {
+		wg.Add(20)
+		for n := 0; n < 20; n++ {
+			go func(number int, blobStore BlobStore) {
+				err := writeANumberWithRetry(number, blobStore)
+				if err != nil {
+					t.Fatal(err)
+				}
+				wg.Done()
+			}(i*20+n+1, blobStore)
+		}
+		wg.Wait()
+	}
+
+	client, err := blobStore.NewClient(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+	object, err := client.NewObject("test.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := object.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sliceData := strings.Split(string(data), "\n")
+	if len(sliceData) != 10*20 {
+		t.Fatal(err)
+	}
+	for i := 0; i < 10*20; i++ {
+		expected := fmt.Sprintf("%05d", i+1)
+		if sliceData[i] != expected {
+			t.Fatal(err)
+		}
 	}
 }

--- a/longtailstorelib/gcsstore.go
+++ b/longtailstorelib/gcsstore.go
@@ -133,7 +133,7 @@ func (blobObject *gcsBlobObject) LockWriteVersion() (bool, error) {
 		return false, err
 	}
 
-	blobObject.writeCondition = &storage.Conditions{MetagenerationMatch: objAttrs.Metageneration, DoesNotExist: false}
+	blobObject.writeCondition = &storage.Conditions{GenerationMatch: objAttrs.Generation, DoesNotExist: false}
 	return true, nil
 }
 

--- a/longtailstorelib/gcsstore.go
+++ b/longtailstorelib/gcsstore.go
@@ -163,9 +163,7 @@ func (blobObject *gcsBlobObject) Write(data []byte) (bool, error) {
 		return false, errors.Wrap(err, blobObject.path)
 	}
 	if e, ok := err2.(*googleapi.Error); ok {
-		if e.Code == writeConditionFailed {
-			return false, nil
-		} else if e.Code == rateLimitExceeded {
+		if e.Code == writeConditionFailed || e.Code == rateLimitExceeded {
 			return false, nil
 		}
 		return false, err2


### PR DESCRIPTION
Use GenerationMatch instead of MetagenerationMatch
Treat rate limit error as a retryable error
Stress test for gcs blob store version lock 