### PR TITLE
feature/put command

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -128,7 +128,7 @@ jobs:
           - **ADDED** `put` commmand to complement `get` commmand
           - **CHANGED** `--get-config-path` option has been removed from `upsync`; use `put` instead.
           - **CHANGED** `--get-config-path` option for `get` renamed to `--source-path`
-          - **FIXED** Automatic resolving of `--target-path` for `downsync` and `get` now resolved to a folder in the local directory
+          - **FIXED** Automatic resolving of `--target-path` for `downsync` and `get` now resolves to a folder in the local directory
         draft: false
         prerelease: false
     - name: Download Linux artifacts

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -125,9 +125,10 @@ jobs:
         release_name: Release ${{ github.ref }}
         body: |
           Changes in this Release
-          - **ADDED** `--zstd_low` and `--zstd_high` compression options
-          - **UPDATED** Updated longtail to v0.3.1
-          - **UPDATED** Updated README.md
+          - **ADDED** `put` commmand to complement `get` commmand
+          - **CHANGED** `--get-config-path` option has been removed from `upsync`; use `put` instead.
+          - **CHANGED** `--get-config-path` option for `get` renamed to `--source-path`
+          - **FIXED** Automatic resolving of `--target-path` for `downsync` and `get` now resolved to a folder in the local directory
         draft: false
         prerelease: false
     - name: Download Linux artifacts

--- a/README.md
+++ b/README.md
@@ -122,9 +122,9 @@ You also need to provide a `--target-path` which is where the version index is s
 
 Optionally (and recommended) you can add a `--version-local-store-index-path` to store a version local store index which is a subset to the full store index required to fullfill this version only. By using that you do not need to download the full store index when you later `downsync` a version.
 
-Finally to make the `downsync` syntax easier and not specify as many parameters, use the `--get-config-path` option to provide a path to a json file which includes the path to the store, version index and optional version local store index. You can use the path to that json file as a single source to `downsync` using `--get-config-path` index instead of specifying the three individual options.
+To reduce the number of parameters to give and keep track on you can use the `get` and `put` commands which let you specify the path to a json file which includes the path to the store, version index and optional version local store index. This command also lets you skip the path to the version index and version local store index and will automatically set them up based on the target name (the json config file).
 
-An example of the structure could look like this:
+An example of the default structure using the `put` command:
 ```
 [bucket]
     store
@@ -134,7 +134,36 @@ An example of the structure could look like this:
                 0000a9c8s8a771242.lsb
                 ...
             ...
-    versions
+    version-store-index
+        v1.lsi
+        v2.lsi
+        ...
+    v1.lvi
+    v2.lvi
+    ...
+```
+
+To achive this structure in GCS the syntax would be:
+`longtail upsync --source-path v1 --target-path gs://bucket/v1.lvi --version-local-store-index-path gs://bucket/version-store-index/v1.lsi --storage-uri gs://bucket/store`
+
+To `downsync` this you would issue:
+`longtail downsync --target-path v1 --source-path gs://bucket/v1.lvi --version-local-store-index-path gs://bucket/version-store-index/v1.lsi --storage-uri gs://bucket/store`
+
+Quite the long command lines, but you will likely automate this rather than do it manually.
+
+You can simplify the syntax by using the `put` and `get` commands:
+
+The default structure for `put`:
+```
+[bucket]
+    store
+        store.lsi
+        chunks
+            0000
+                0000a9c8s8a771242.lsb
+                ...
+            ...
+    version-data
         version-index
             v1.lvi
             v2.lvi
@@ -143,28 +172,23 @@ An example of the structure could look like this:
             v1.lsi
             v2.lsi
             ...
-        v1.json
-        v2.json
-        ...
+    v1.json
+    v2.json
+    ...
 ```
 
-To achive this structure in GCS the syntax would be:
-`longtail upsync --source-path v1 --target-path gs://bucket/versions/version-index/v1.lvi --version-local-store-index-path gs://bucket/versions/version-store-index/v1.lsi --storage-uri gs://bucket/store`
+`longtail put --source-path v1 --target-path gs://bucket/v1.json`
+`longtail get --source-path gs://bucket/v1.json`
 
-To `downsync` this you would issue:
-`longtail downsync --target-path v1 --source-path gs://bucket/versions/version-index/v1.lvi --version-local-store-index-path gs://bucket/versions/version-store-index/v1.lsi --storage-uri gs://bucket/store`
+The `--target-path` is optional for `get` and longtail will deduce the target folder name from the `source-path` path, in this case it will be a folder called `v1` in the current directory.
 
-Quite the long command lines, but you will likely automate this rather than do it manually.
-
-You can simplify the syntax for `downsync` by adding the `--get-config-path` option to create a json file that includes all the separate details. Extended the command line with `--get-config-path gs://bucket/versions/v1.json`, and getting the version is quite a bit simpler:
-
-`longtail get --get-config-path gs://bucket/versions/v1.json`. The `--target-path` is optional and longtail will deduce the target folder name from the `get-config-path` path, in this case it will be called `v1`.
+You can still use the `put` command and override the `--storage-uri`, `target-version-index-path` and `version-local-store-index-path` if you want a different structure.
 
 ### Caching data between versions
 By default longtail `downsync` or `get` does not cache any downloaded blocks from the store. This works fairly well since it will only download data for the files that needs to be modified/added, but if you care about download size you do want to create a cache of blocks to use between versions.
 
 You do this using the `--cache-path` option, like this:
-`longtail get --get-config-path gs://bucket/versions/v1.json --cache-path /tmp/longtail-cache`
+`longtail get --source-path gs://bucket/versions/v1.json --cache-path /tmp/longtail-cache`
 
 The cache will save every block that you download from the store and will use blocks from the cache as a primary source of data.
 
@@ -219,14 +243,14 @@ Longtail uses a mechanism of writing partial store indexes and merging them on t
 ### Download from a local folder
 `longtail.exe downsync --source-path "local_store/index/my_folder.lvi" --target-path "my_folder_copy" --storage-uri "local_store"`
 
-### Upload to GCS with version local store index and a `get-info` file
-`longtail.exe upsync --source-path "my_folder" --target-path "gs://test_block_storage/store/index/my_folder.lvi" --storage-uri "gs://test_block_storage/store" --version-local-store-index-path "gs://test_block_storage/store/index/my_folder.lsi" --get-config-path "gs://test_block_storage/store/index/my_folder.json"`
+### Upload to GCS with version local store index and a `get-config` file
+`longtail.exe put --source-path "my_folder" --target-path "gs://test_block_storage/store/index/my_folder.json"`
 
-### Download from GCS using version local store index and a `get-info` file
-`longtail.exe get --get-config-path "gs://test_block_storage/store/index/my_folder.json"`
+### Download from GCS using version local store index and a `get-config` file into default folder `my_folder`
+`longtail.exe get --source-path "gs://test_block_storage/store/index/my_folder.json"`
 
-### Download from GCS using version local store index and a `get-info` file with a cache
-`longtail.exe get --get-config-path "gs://test_block_storage/store/index/my_folder.json" --cache-path "./download-cache"`
+### Download from GCS using version local store index and a `get-config` file with a cache into custom folder `download/target_folder`
+`longtail.exe get --source-path "gs://test_block_storage/store/index/my_folder.json" --cache-path "./download-cache" --target-path "download/target_folder"`
 
 ### Create a self-containing archive from a folder naming the archive using the source name
 `longtail.exe pack --source-path "stuff/my_folder"`

--- a/README.md
+++ b/README.md
@@ -111,20 +111,18 @@ To minimize downloads even more, longtail has support for a download cache where
 ## Usage
 Build the command line and run it using `longtail --help` for a breif description of commands/options.
 
-## Guidelines for uploading and downloading from a delta store
+## Guidelines for uploading and downloading using a delta store
 
 ### Structure
 
-To `upsync` you should provide a `--storage-uri` - this is where the data is stored for all versions including an index over all the data, an example for GCS would be `gs://my_bucket/store` and for S3 `s3://my_bucket/store` which creates a folder in `my_bucket`.
+To `upsync` you should provide a `--storage-uri` - this is where the data is stored for all versions including an index over all the data. An example for GCS would be `gs://my_bucket/store` and for S3 `s3://my_bucket/store` which creates a folder calls `store` in the bucket `my_bucket`.
 The bucket must already be created and have proper access rights - for upload you need to be able to create objects, read and write to them, list objects and read/write meta-data.
 
 You also need to provide a `--target-path` which is where the version index is stored. I recommend that you put that in a separate folder in your bucket.
 
 Optionally (and recommended) you can add a `--version-local-store-index-path` to store a version local store index which is a subset to the full store index required to fullfill this version only. By using that you do not need to download the full store index when you later `downsync` a version.
 
-To reduce the number of parameters to give and keep track on you can use the `get` and `put` commands which let you specify the path to a json file which includes the path to the store, version index and optional version local store index. This command also lets you skip the path to the version index and version local store index and will automatically set them up based on the target name (the json config file).
-
-An example of the default structure using the `put` command:
+An example of the structure using the `upsync` command:
 ```
 [bucket]
     store
@@ -151,7 +149,7 @@ To `downsync` this you would issue:
 
 Quite the long command lines, but you will likely automate this rather than do it manually.
 
-You can simplify the syntax by using the `put` and `get` commands:
+To reduce the number of parameters to give and keep track on you can use the `get` and `put` commands which let you specify the path to a json file which includes the path to the store, version index and optional version local store index. This command also lets you skip the path to the version index, version local store index and store and will automatically set them up based on the target name (the json config file).
 
 The default structure for `put`:
 ```
@@ -178,11 +176,12 @@ The default structure for `put`:
 ```
 
 `longtail put --source-path v1 --target-path gs://bucket/v1.json`
+
 `longtail get --source-path gs://bucket/v1.json`
 
-The `--target-path` is optional for `get` and longtail will deduce the target folder name from the `source-path` path, in this case it will be a folder called `v1` in the current directory.
+The `--target-path` is optional for `get` and longtail will deduce the target folder name from the `--source-path` path, in this case it will be a folder called `v1` in the current directory.
 
-You can still use the `put` command and override the `--storage-uri`, `target-version-index-path` and `version-local-store-index-path` if you want a different structure.
+You can use the `put` command and override the `--storage-uri`, `--target-version-index-path` and `--version-local-store-index-path` if you want a different structure, the `get` command will still be simple as the paths to the individual parts will be stored in the .json file.
 
 ### Caching data between versions
 By default longtail `downsync` or `get` does not cache any downloaded blocks from the store. This works fairly well since it will only download data for the files that needs to be modified/added, but if you care about download size you do want to create a cache of blocks to use between versions.

--- a/commands/cmd_downsync.go
+++ b/commands/cmd_downsync.go
@@ -62,7 +62,9 @@ func downsync(
 
 	resolvedTargetFolderPath := ""
 	if targetFolderPath == "" {
-		urlSplit := strings.Split(longtailutils.NormalizePath(sourceFilePath), "/")
+		normalizedSourceFilePath := longtailutils.NormalizePath(sourceFilePath)
+		normalizedSourceFilePath = strings.ReplaceAll(normalizedSourceFilePath, "\\", "/")
+		urlSplit := strings.Split(normalizedSourceFilePath, "/")
 		sourceName := urlSplit[len(urlSplit)-1]
 		sourceNameSplit := strings.Split(sourceName, ".")
 		resolvedTargetFolderPath = sourceNameSplit[0]

--- a/commands/cmd_get.go
+++ b/commands/cmd_get.go
@@ -100,7 +100,7 @@ func get(
 }
 
 type GetCmd struct {
-	GetConfigURI string `name:"get-config-path" help:"File uri for json formatted get-config file" required:""`
+	GetConfigURI string `name:"source-path" help:"File uri for json formatted get-config file" required:""`
 	TargetPathOption
 	TargetIndexUriOption
 	ValidateTargetOption

--- a/commands/cmd_get_test.go
+++ b/commands/cmd_get_test.go
@@ -10,21 +10,21 @@ func TestGet(t *testing.T) {
 	fsBlobPathPrefix := "fsblob://" + testPath
 	createVersionData(t, fsBlobPathPrefix)
 
-	executeCommandLine("upsync", "--source-path", testPath+"/version/v1", "--target-path", fsBlobPathPrefix+"/index/v1.lvi", "--storage-uri", fsBlobPathPrefix+"/storage", "--get-config-path", fsBlobPathPrefix+"/index/v1.json")
-	executeCommandLine("upsync", "--source-path", testPath+"/version/v2", "--target-path", fsBlobPathPrefix+"/index/v2.lvi", "--storage-uri", fsBlobPathPrefix+"/storage", "--get-config-path", fsBlobPathPrefix+"/index/v2.json")
-	executeCommandLine("upsync", "--source-path", testPath+"/version/v3", "--target-path", fsBlobPathPrefix+"/index/v3.lvi", "--storage-uri", fsBlobPathPrefix+"/storage", "--get-config-path", fsBlobPathPrefix+"/index/v3.json")
+	executeCommandLine("put", "--source-path", testPath+"/version/v1", "--target-path", fsBlobPathPrefix+"/index/v1.json", "--storage-uri", fsBlobPathPrefix+"/storage")
+	executeCommandLine("put", "--source-path", testPath+"/version/v2", "--target-path", fsBlobPathPrefix+"/index/v2.json", "--storage-uri", fsBlobPathPrefix+"/storage")
+	executeCommandLine("put", "--source-path", testPath+"/version/v3", "--target-path", fsBlobPathPrefix+"/index/v3.json", "--storage-uri", fsBlobPathPrefix+"/storage")
 
-	cmd, err := executeCommandLine("get", "--get-config-path", fsBlobPathPrefix+"/index/v1.json", "--target-path", testPath+"/version/current")
+	cmd, err := executeCommandLine("get", "--source-path", fsBlobPathPrefix+"/index/v1.json", "--target-path", testPath+"/version/current")
 	if err != nil {
 		t.Errorf("%s: %s", cmd, err)
 	}
 	validateContent(t, fsBlobPathPrefix, "version/current", v1FilesCreate)
-	cmd, err = executeCommandLine("get", "--get-config-path", fsBlobPathPrefix+"/index/v2.json", "--target-path", testPath+"/version/current")
+	cmd, err = executeCommandLine("get", "--source-path", fsBlobPathPrefix+"/index/v2.json", "--target-path", testPath+"/version/current")
 	if err != nil {
 		t.Errorf("%s: %s", cmd, err)
 	}
 	validateContent(t, fsBlobPathPrefix, "version/current", v2FilesCreate)
-	cmd, err = executeCommandLine("get", "--get-config-path", fsBlobPathPrefix+"/index/v3.json", "--target-path", testPath+"/version/current")
+	cmd, err = executeCommandLine("get", "--source-path", fsBlobPathPrefix+"/index/v3.json", "--target-path", testPath+"/version/current")
 	if err != nil {
 		t.Errorf("%s: %s", cmd, err)
 	}
@@ -36,21 +36,21 @@ func TestGetWithVersionLSI(t *testing.T) {
 	fsBlobPathPrefix := "fsblob://" + testPath
 	createVersionData(t, fsBlobPathPrefix)
 
-	executeCommandLine("upsync", "--source-path", testPath+"/version/v1", "--target-path", fsBlobPathPrefix+"/index/v1.lvi", "--storage-uri", fsBlobPathPrefix+"/storage", "--get-config-path", fsBlobPathPrefix+"/index/v1.json", "--version-local-store-index-path", fsBlobPathPrefix+"/index/v1.lsi")
-	executeCommandLine("upsync", "--source-path", testPath+"/version/v2", "--target-path", fsBlobPathPrefix+"/index/v2.lvi", "--storage-uri", fsBlobPathPrefix+"/storage", "--get-config-path", fsBlobPathPrefix+"/index/v2.json", "--version-local-store-index-path", fsBlobPathPrefix+"/index/v2.lsi")
-	executeCommandLine("upsync", "--source-path", testPath+"/version/v3", "--target-path", fsBlobPathPrefix+"/index/v3.lvi", "--storage-uri", fsBlobPathPrefix+"/storage", "--get-config-path", fsBlobPathPrefix+"/index/v3.json", "--version-local-store-index-path", fsBlobPathPrefix+"/index/v3.lsi")
+	executeCommandLine("put", "--source-path", testPath+"/version/v1", "--target-path", fsBlobPathPrefix+"/index/v1.json", "--storage-uri", fsBlobPathPrefix+"/storage", "--version-local-store-index-path", fsBlobPathPrefix+"/index/v1.lsi")
+	executeCommandLine("put", "--source-path", testPath+"/version/v2", "--target-path", fsBlobPathPrefix+"/index/v2.json", "--storage-uri", fsBlobPathPrefix+"/storage", "--version-local-store-index-path", fsBlobPathPrefix+"/index/v2.lsi")
+	executeCommandLine("put", "--source-path", testPath+"/version/v3", "--target-path", fsBlobPathPrefix+"/index/v3.json", "--storage-uri", fsBlobPathPrefix+"/storage", "--version-local-store-index-path", fsBlobPathPrefix+"/index/v3.lsi")
 
-	cmd, err := executeCommandLine("get", "--get-config-path", fsBlobPathPrefix+"/index/v1.json", "--target-path", testPath+"/version/current")
+	cmd, err := executeCommandLine("get", "--source-path", fsBlobPathPrefix+"/index/v1.json", "--target-path", testPath+"/version/current")
 	if err != nil {
 		t.Errorf("%s: %s", cmd, err)
 	}
 	validateContent(t, fsBlobPathPrefix, "version/current", v1FilesCreate)
-	cmd, err = executeCommandLine("get", "--get-config-path", fsBlobPathPrefix+"/index/v2.json", "--target-path", testPath+"/version/current")
+	cmd, err = executeCommandLine("get", "--source-path", fsBlobPathPrefix+"/index/v2.json", "--target-path", testPath+"/version/current")
 	if err != nil {
 		t.Errorf("%s: %s", cmd, err)
 	}
 	validateContent(t, fsBlobPathPrefix, "version/current", v2FilesCreate)
-	cmd, err = executeCommandLine("get", "--get-config-path", fsBlobPathPrefix+"/index/v3.json", "--target-path", testPath+"/version/current")
+	cmd, err = executeCommandLine("get", "--source-path", fsBlobPathPrefix+"/index/v3.json", "--target-path", testPath+"/version/current")
 	if err != nil {
 		t.Errorf("%s: %s", cmd, err)
 	}
@@ -61,21 +61,21 @@ func TestGetWithCache(t *testing.T) {
 	testPath, _ := ioutil.TempDir("", "test")
 	fsBlobPathPrefix := "fsblob://" + testPath
 	createVersionData(t, fsBlobPathPrefix)
-	executeCommandLine("upsync", "--source-path", testPath+"/version/v1", "--target-path", fsBlobPathPrefix+"/index/v1.lvi", "--storage-uri", fsBlobPathPrefix+"/storage", "--get-config-path", fsBlobPathPrefix+"/index/v1.json")
-	executeCommandLine("upsync", "--source-path", testPath+"/version/v2", "--target-path", fsBlobPathPrefix+"/index/v2.lvi", "--storage-uri", fsBlobPathPrefix+"/storage", "--get-config-path", fsBlobPathPrefix+"/index/v2.json")
-	executeCommandLine("upsync", "--source-path", testPath+"/version/v3", "--target-path", fsBlobPathPrefix+"/index/v3.lvi", "--storage-uri", fsBlobPathPrefix+"/storage", "--get-config-path", fsBlobPathPrefix+"/index/v3.json")
+	executeCommandLine("put", "--source-path", testPath+"/version/v1", "--target-path", fsBlobPathPrefix+"/index/v1.json", "--storage-uri", fsBlobPathPrefix+"/storage")
+	executeCommandLine("put", "--source-path", testPath+"/version/v2", "--target-path", fsBlobPathPrefix+"/index/v2.json", "--storage-uri", fsBlobPathPrefix+"/storage")
+	executeCommandLine("put", "--source-path", testPath+"/version/v3", "--target-path", fsBlobPathPrefix+"/index/v3.json", "--storage-uri", fsBlobPathPrefix+"/storage")
 
-	cmd, err := executeCommandLine("get", "--get-config-path", fsBlobPathPrefix+"/index/v1.json", "--target-path", testPath+"/version/current", "--cache-path", testPath+"/cache")
+	cmd, err := executeCommandLine("get", "--source-path", fsBlobPathPrefix+"/index/v1.json", "--target-path", testPath+"/version/current", "--cache-path", testPath+"/cache")
 	if err != nil {
 		t.Errorf("%s: %s", cmd, err)
 	}
 	validateContent(t, fsBlobPathPrefix, "version/current", v1FilesCreate)
-	cmd, err = executeCommandLine("get", "--get-config-path", fsBlobPathPrefix+"/index/v2.json", "--target-path", testPath+"/version/current", "--cache-path", testPath+"/cache")
+	cmd, err = executeCommandLine("get", "--source-path", fsBlobPathPrefix+"/index/v2.json", "--target-path", testPath+"/version/current", "--cache-path", testPath+"/cache")
 	if err != nil {
 		t.Errorf("%s: %s", cmd, err)
 	}
 	validateContent(t, fsBlobPathPrefix, "version/current", v2FilesCreate)
-	cmd, err = executeCommandLine("get", "--get-config-path", fsBlobPathPrefix+"/index/v3.json", "--target-path", testPath+"/version/current", "--cache-path", testPath+"/cache")
+	cmd, err = executeCommandLine("get", "--source-path", fsBlobPathPrefix+"/index/v3.json", "--target-path", testPath+"/version/current", "--cache-path", testPath+"/cache")
 	if err != nil {
 		t.Errorf("%s: %s", cmd, err)
 	}
@@ -86,21 +86,21 @@ func TestGetWithLSIAndCache(t *testing.T) {
 	testPath, _ := ioutil.TempDir("", "test")
 	fsBlobPathPrefix := "fsblob://" + testPath
 	createVersionData(t, fsBlobPathPrefix)
-	executeCommandLine("upsync", "--source-path", testPath+"/version/v1", "--target-path", fsBlobPathPrefix+"/index/v1.lvi", "--storage-uri", fsBlobPathPrefix+"/storage", "--get-config-path", fsBlobPathPrefix+"/index/v1.json", "--version-local-store-index-path", fsBlobPathPrefix+"/index/v1.lsi")
-	executeCommandLine("upsync", "--source-path", testPath+"/version/v2", "--target-path", fsBlobPathPrefix+"/index/v2.lvi", "--storage-uri", fsBlobPathPrefix+"/storage", "--get-config-path", fsBlobPathPrefix+"/index/v2.json", "--version-local-store-index-path", fsBlobPathPrefix+"/index/v2.lsi")
-	executeCommandLine("upsync", "--source-path", testPath+"/version/v3", "--target-path", fsBlobPathPrefix+"/index/v3.lvi", "--storage-uri", fsBlobPathPrefix+"/storage", "--get-config-path", fsBlobPathPrefix+"/index/v3.json", "--version-local-store-index-path", fsBlobPathPrefix+"/index/v3.lsi")
+	executeCommandLine("put", "--source-path", testPath+"/version/v1", "--target-path", fsBlobPathPrefix+"/index/v1.json", "--storage-uri", fsBlobPathPrefix+"/storage", "--version-local-store-index-path", fsBlobPathPrefix+"/index/v1.lsi")
+	executeCommandLine("put", "--source-path", testPath+"/version/v2", "--target-path", fsBlobPathPrefix+"/index/v2.json", "--storage-uri", fsBlobPathPrefix+"/storage", "--version-local-store-index-path", fsBlobPathPrefix+"/index/v2.lsi")
+	executeCommandLine("put", "--source-path", testPath+"/version/v3", "--target-path", fsBlobPathPrefix+"/index/v3.json", "--storage-uri", fsBlobPathPrefix+"/storage", "--version-local-store-index-path", fsBlobPathPrefix+"/index/v3.lsi")
 
-	cmd, err := executeCommandLine("get", "--get-config-path", fsBlobPathPrefix+"/index/v1.json", "--target-path", testPath+"/version/current", "--cache-path", testPath+"/cache")
+	cmd, err := executeCommandLine("get", "--source-path", fsBlobPathPrefix+"/index/v1.json", "--target-path", testPath+"/version/current", "--cache-path", testPath+"/cache")
 	if err != nil {
 		t.Errorf("%s: %s", cmd, err)
 	}
 	validateContent(t, fsBlobPathPrefix, "version/current", v1FilesCreate)
-	cmd, err = executeCommandLine("get", "--get-config-path", fsBlobPathPrefix+"/index/v2.json", "--target-path", testPath+"/version/current", "--cache-path", testPath+"/cache")
+	cmd, err = executeCommandLine("get", "--source-path", fsBlobPathPrefix+"/index/v2.json", "--target-path", testPath+"/version/current", "--cache-path", testPath+"/cache")
 	if err != nil {
 		t.Errorf("%s: %s", cmd, err)
 	}
 	validateContent(t, fsBlobPathPrefix, "version/current", v2FilesCreate)
-	cmd, err = executeCommandLine("get", "--get-config-path", fsBlobPathPrefix+"/index/v3.json", "--target-path", testPath+"/version/current", "--cache-path", testPath+"/cache")
+	cmd, err = executeCommandLine("get", "--source-path", fsBlobPathPrefix+"/index/v3.json", "--target-path", testPath+"/version/current", "--cache-path", testPath+"/cache")
 	if err != nil {
 		t.Errorf("%s: %s", cmd, err)
 	}

--- a/commands/cmd_initremotestore_test.go
+++ b/commands/cmd_initremotestore_test.go
@@ -43,9 +43,9 @@ func TestInitRemoteStore(t *testing.T) {
 
 	createVersionData(t, fsBlobPathPrefix)
 
-	executeCommandLine("upsync", "--source-path", testPath+"/version/v1", "--target-path", fsBlobPathPrefix+"/index/v1.lvi", "--storage-uri", fsBlobPathPrefix+"/storage", "--get-config-path", fsBlobPathPrefix+"/index/v1.json")
-	executeCommandLine("upsync", "--source-path", testPath+"/version/v2", "--target-path", fsBlobPathPrefix+"/index/v2.lvi", "--storage-uri", fsBlobPathPrefix+"/storage", "--get-config-path", fsBlobPathPrefix+"/index/v2.json")
-	executeCommandLine("upsync", "--source-path", testPath+"/version/v3", "--target-path", fsBlobPathPrefix+"/index/v3.lvi", "--storage-uri", fsBlobPathPrefix+"/storage", "--get-config-path", fsBlobPathPrefix+"/index/v3.json")
+	executeCommandLine("put", "--source-path", testPath+"/version/v1", "--target-path", fsBlobPathPrefix+"/index/v1.json", "--storage-uri", fsBlobPathPrefix+"/storage")
+	executeCommandLine("put", "--source-path", testPath+"/version/v2", "--target-path", fsBlobPathPrefix+"/index/v2.json", "--storage-uri", fsBlobPathPrefix+"/storage")
+	executeCommandLine("put", "--source-path", testPath+"/version/v3", "--target-path", fsBlobPathPrefix+"/index/v3.json", "--storage-uri", fsBlobPathPrefix+"/storage")
 
 	// Kill the index file so we can do init again
 	store, _ := longtailstorelib.CreateBlobStoreForURI(fsBlobPathPrefix)
@@ -60,11 +60,11 @@ func TestInitRemoteStore(t *testing.T) {
 		t.Errorf("%s: %s", cmd, err)
 	}
 
-	executeCommandLine("get", "--get-config-path", fsBlobPathPrefix+"/index/v1.json", "--target-path", testPath+"/version/current")
+	executeCommandLine("get", "--source-path", fsBlobPathPrefix+"/index/v1.json", "--target-path", testPath+"/version/current")
 	validateContent(t, fsBlobPathPrefix, "version/current", v1FilesCreate)
-	executeCommandLine("get", "--get-config-path", fsBlobPathPrefix+"/index/v2.json", "--target-path", testPath+"/version/current")
+	executeCommandLine("get", "--source-path", fsBlobPathPrefix+"/index/v2.json", "--target-path", testPath+"/version/current")
 	validateContent(t, fsBlobPathPrefix, "version/current", v2FilesCreate)
-	executeCommandLine("get", "--get-config-path", fsBlobPathPrefix+"/index/v3.json", "--target-path", testPath+"/version/current")
+	executeCommandLine("get", "--source-path", fsBlobPathPrefix+"/index/v3.json", "--target-path", testPath+"/version/current")
 	validateContent(t, fsBlobPathPrefix, "version/current", v3FilesCreate)
 
 	storeIndexObject.Delete()
@@ -78,10 +78,10 @@ func TestInitRemoteStore(t *testing.T) {
 		t.Errorf("%s: %s", cmd, err)
 	}
 
-	executeCommandLine("get", "--get-config-path", fsBlobPathPrefix+"/index/v1.json", "--target-path", testPath+"/version/current")
+	executeCommandLine("get", "--source-path", fsBlobPathPrefix+"/index/v1.json", "--target-path", testPath+"/version/current")
 	validateContent(t, fsBlobPathPrefix, "version/current", v1FilesCreate)
-	executeCommandLine("get", "--get-config-path", fsBlobPathPrefix+"/index/v2.json", "--target-path", testPath+"/version/current")
+	executeCommandLine("get", "--source-path", fsBlobPathPrefix+"/index/v2.json", "--target-path", testPath+"/version/current")
 	validateContent(t, fsBlobPathPrefix, "version/current", v2FilesCreate)
-	executeCommandLine("get", "--get-config-path", fsBlobPathPrefix+"/index/v3.json", "--target-path", testPath+"/version/current")
+	executeCommandLine("get", "--source-path", fsBlobPathPrefix+"/index/v3.json", "--target-path", testPath+"/version/current")
 	validateContent(t, fsBlobPathPrefix, "version/current", v3FilesCreate)
 }

--- a/commands/cmd_put.go
+++ b/commands/cmd_put.go
@@ -1,0 +1,141 @@
+package commands
+
+import (
+	"context"
+	"strings"
+
+	"github.com/DanEngelbrecht/golongtail/longtailutils"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+func put(
+	numWorkerCount int,
+	blobStoreURI string,
+	sourceFolderPath string,
+	sourceIndexPath string,
+	targetIndexFilePath string,
+	targetChunkSize uint32,
+	targetBlockSize uint32,
+	maxChunksPerBlock uint32,
+	compressionAlgorithm string,
+	hashAlgorithm string,
+	includeFilterRegEx string,
+	excludeFilterRegEx string,
+	minBlockUsagePercent uint32,
+	versionLocalStoreIndexPath string,
+	targetPath string,
+	enableFileMapping bool) ([]longtailutils.StoreStat, []longtailutils.TimeStat, error) {
+	const fname = "put"
+	log := logrus.WithContext(context.Background()).WithFields(logrus.Fields{
+		"fname":                      fname,
+		"numWorkerCount":             numWorkerCount,
+		"blobStoreURI":               blobStoreURI,
+		"sourceFolderPath":           sourceFolderPath,
+		"sourceIndexPath":            sourceIndexPath,
+		"targetIndexFilePath":        targetIndexFilePath,
+		"targetChunkSize":            targetChunkSize,
+		"targetBlockSize":            targetBlockSize,
+		"maxChunksPerBlock":          maxChunksPerBlock,
+		"compressionAlgorithm":       compressionAlgorithm,
+		"hashAlgorithm":              hashAlgorithm,
+		"includeFilterRegEx":         includeFilterRegEx,
+		"excludeFilterRegEx":         excludeFilterRegEx,
+		"minBlockUsagePercent":       minBlockUsagePercent,
+		"versionLocalStoreIndexPath": versionLocalStoreIndexPath,
+		"targetPath":                 targetPath,
+		"enableFileMapping":          enableFileMapping,
+	})
+	log.Debug(fname)
+
+	storeStats := []longtailutils.StoreStat{}
+	timeStats := []longtailutils.TimeStat{}
+
+	parentPath := ""
+	pathDelimiter := strings.LastIndexAny(targetPath, "\\/")
+	if pathDelimiter != -1 {
+		parentPath = targetPath[0:pathDelimiter]
+	}
+	configPathName := targetPath
+	extensionDelimiter := strings.LastIndexAny(targetPath, ".")
+	if extensionDelimiter != -1 {
+		configPathName = configPathName[0:extensionDelimiter]
+	}
+
+	if blobStoreURI == "" {
+		blobStoreURI = parentPath + "/store"
+	}
+
+	if targetIndexFilePath == "" {
+		targetIndexFilePath = configPathName + ".lvi"
+	}
+
+	if versionLocalStoreIndexPath == "" {
+		versionLocalStoreIndexPath = configPathName + ".lsi"
+	}
+
+	downSyncStoreStats, downSyncTimeStats, err := upsync(
+		numWorkerCount,
+		blobStoreURI,
+		sourceFolderPath,
+		sourceIndexPath,
+		targetIndexFilePath,
+		targetChunkSize,
+		targetBlockSize,
+		maxChunksPerBlock,
+		compressionAlgorithm,
+		hashAlgorithm,
+		includeFilterRegEx,
+		excludeFilterRegEx,
+		minBlockUsagePercent,
+		versionLocalStoreIndexPath,
+		targetPath,
+		enableFileMapping)
+
+	storeStats = append(storeStats, downSyncStoreStats...)
+	timeStats = append(timeStats, downSyncTimeStats...)
+
+	return storeStats, timeStats, errors.Wrap(err, fname)
+}
+
+type PutCmd struct {
+	GetConfigURI               string `name:"target-path" help:"File uri for json formatted get-config file" required:""`
+	TargetFileIndexPath        string `name:"target-index-path" help:"Target index file uri"`
+	VersionLocalStoreIndexPath string `name:"version-local-store-index-path" help:"Target file uri for a store index optimized for this particular version"`
+	OptionalStorageURI         string `name:"storage-uri" help"Storage URI (local file system, GCS and S3 bucket URI supported)"`
+	SourcePath                 string `name:"source-path" help:"Source folder path" required:""`
+	SourceIndexPath            string `name:"source-index-path" help:"Optional pre-computed index of source-path"`
+	TargetChunkSizeOption
+	TargetBlockSizeOption
+	MaxChunksPerBlockOption
+	CompressionOption
+	HashingOption
+	SourcePathIncludeRegExOption
+	SourcePathExcludeRegExOption
+	MinBlockUsagePercentOption
+
+	EnableFileMappingOption
+}
+
+func (r *PutCmd) Run(ctx *Context) error {
+	storeStats, timeStats, err := put(
+		ctx.NumWorkerCount,
+		r.OptionalStorageURI,
+		r.SourcePath,
+		r.SourceIndexPath,
+		r.TargetFileIndexPath,
+		r.TargetChunkSize,
+		r.TargetBlockSize,
+		r.MaxChunksPerBlock,
+		r.Compression,
+		r.Hashing,
+		r.IncludeFilterRegEx,
+		r.ExcludeFilterRegEx,
+		r.MinBlockUsagePercent,
+		r.VersionLocalStoreIndexPath,
+		r.GetConfigURI,
+		r.EnableFileMapping)
+	ctx.StoreStats = append(ctx.StoreStats, storeStats...)
+	ctx.TimeStats = append(ctx.TimeStats, timeStats...)
+	return err
+}

--- a/commands/cmd_upsync_test.go
+++ b/commands/cmd_upsync_test.go
@@ -42,39 +42,39 @@ func TestUpsyncWithLSI(t *testing.T) {
 	}
 }
 
-func TestUpsyncWithGetConfig(t *testing.T) {
-	testPath, _ := ioutil.TempDir("", "test")
-	fsBlobPathPrefix := "fsblob://" + testPath
-	createVersionData(t, fsBlobPathPrefix)
-
-	cmd, err := executeCommandLine("upsync", "--source-path", testPath+"/version/v1", "--target-path", fsBlobPathPrefix+"/index/v1.lvi", "--storage-uri", fsBlobPathPrefix+"/storage", "--get-config-path", fsBlobPathPrefix+"/index/v1.json")
-	if err != nil {
-		t.Errorf("%s: %s", cmd, err)
-	}
-	cmd, err = executeCommandLine("upsync", "--source-path", testPath+"/version/v2", "--target-path", fsBlobPathPrefix+"/index/v2.lvi", "--storage-uri", fsBlobPathPrefix+"/storage", "--get-config-path", fsBlobPathPrefix+"/index/v2.json")
-	if err != nil {
-		t.Errorf("%s: %s", cmd, err)
-	}
-	cmd, err = executeCommandLine("upsync", "--source-path", testPath+"/version/v3", "--target-path", fsBlobPathPrefix+"/index/v3.lvi", "--storage-uri", fsBlobPathPrefix+"/storage", "--get-config-path", fsBlobPathPrefix+"/index/v3.json")
-	if err != nil {
-		t.Errorf("%s: %s", cmd, err)
-	}
-}
-
-func TestUpsyncWithGetConfigAndLSI(t *testing.T) {
-	testPath, _ := ioutil.TempDir("", "test")
-	fsBlobPathPrefix := "fsblob://" + testPath
-	createVersionData(t, fsBlobPathPrefix)
-	cmd, err := executeCommandLine("upsync", "--source-path", testPath+"/version/v1", "--target-path", fsBlobPathPrefix+"/index/v1.lvi", "--storage-uri", fsBlobPathPrefix+"/storage", "--get-config-path", fsBlobPathPrefix+"/index/v1.json", "--version-local-store-index-path", fsBlobPathPrefix+"/index/v1.lsi")
-	if err != nil {
-		t.Errorf("%s: %s", cmd, err)
-	}
-	cmd, err = executeCommandLine("upsync", "--source-path", testPath+"/version/v2", "--target-path", fsBlobPathPrefix+"/index/v2.lvi", "--storage-uri", fsBlobPathPrefix+"/storage", "--get-config-path", fsBlobPathPrefix+"/index/v2.json", "--version-local-store-index-path", fsBlobPathPrefix+"/index/v2.lsi")
-	if err != nil {
-		t.Errorf("%s: %s", cmd, err)
-	}
-	cmd, err = executeCommandLine("upsync", "--source-path", testPath+"/version/v3", "--target-path", fsBlobPathPrefix+"/index/v3.lvi", "--storage-uri", fsBlobPathPrefix+"/storage", "--get-config-path", fsBlobPathPrefix+"/index/v3.json", "--version-local-store-index-path", fsBlobPathPrefix+"/index/v3.lsi")
-	if err != nil {
-		t.Errorf("%s: %s", cmd, err)
-	}
-}
+//func TestUpsyncWithGetConfig(t *testing.T) {
+//	testPath, _ := ioutil.TempDir("", "test")
+//	fsBlobPathPrefix := "fsblob://" + testPath
+//	createVersionData(t, fsBlobPathPrefix)
+//
+//	cmd, err := executeCommandLine("upsync", "--source-path", testPath+"/version/v1", "--target-path", fsBlobPathPrefix+"/index/v1.lvi", "--storage-uri", fsBlobPathPrefix+"/storage", "--get-config-path", fsBlobPathPrefix+"/index/v1.json")
+//	if err != nil {
+//		t.Errorf("%s: %s", cmd, err)
+//	}
+//	cmd, err = executeCommandLine("upsync", "--source-path", testPath+"/version/v2", "--target-path", fsBlobPathPrefix+"/index/v2.lvi", "--storage-uri", fsBlobPathPrefix+"/storage", "--get-config-path", fsBlobPathPrefix+"/index/v2.json")
+//	if err != nil {
+//		t.Errorf("%s: %s", cmd, err)
+//	}
+//	cmd, err = executeCommandLine("upsync", "--source-path", testPath+"/version/v3", "--target-path", fsBlobPathPrefix+"/index/v3.lvi", "--storage-uri", fsBlobPathPrefix+"/storage", "--get-config-path", fsBlobPathPrefix+"/index/v3.json")
+//	if err != nil {
+//		t.Errorf("%s: %s", cmd, err)
+//	}
+//}
+//
+//func TestUpsyncWithGetConfigAndLSI(t *testing.T) {
+//	testPath, _ := ioutil.TempDir("", "test")
+//	fsBlobPathPrefix := "fsblob://" + testPath
+//	createVersionData(t, fsBlobPathPrefix)
+//	cmd, err := executeCommandLine("upsync", "--source-path", testPath+"/version/v1", "--target-path", fsBlobPathPrefix+"/index/v1.lvi", "--storage-uri", fsBlobPathPrefix+"/storage", "--get-config-path", fsBlobPathPrefix+"/index/v1.json", "--version-local-store-index-path", fsBlobPathPrefix+"/index/v1.lsi")
+//	if err != nil {
+//		t.Errorf("%s: %s", cmd, err)
+//	}
+//	cmd, err = executeCommandLine("upsync", "--source-path", testPath+"/version/v2", "--target-path", fsBlobPathPrefix+"/index/v2.lvi", "--storage-uri", fsBlobPathPrefix+"/storage", "--get-config-path", fsBlobPathPrefix+"/index/v2.json", "--version-local-store-index-path", fsBlobPathPrefix+"/index/v2.lsi")
+//	if err != nil {
+//		t.Errorf("%s: %s", cmd, err)
+//	}
+//	cmd, err = executeCommandLine("upsync", "--source-path", testPath+"/version/v3", "--target-path", fsBlobPathPrefix+"/index/v3.lvi", "--storage-uri", fsBlobPathPrefix+"/storage", "--get-config-path", fsBlobPathPrefix+"/index/v3.json", "--version-local-store-index-path", fsBlobPathPrefix+"/index/v3.lsi")
+//	if err != nil {
+//		t.Errorf("%s: %s", cmd, err)
+//	}
+//}

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -28,4 +28,5 @@ var Cli struct {
 	Version                 VersionCmd                 `cmd:"" name:"version" help:"Show version number"`
 	Pack                    PackCmd                    `cmd:"" name:"pack" help:"Pack a source to an archive"`
 	Unpack                  UnpackCmd                  `cmd:"" name:"unpack" help:"Unpack an archive"`
+	Put                     PutCmd                     `cmd:"" name:"put" help:"Upload a folder"`
 }


### PR DESCRIPTION
- **ADDED** `put` commmand to complement `get` commmand
- **CHANGED** `--get-config-path` option has been removed from `upsync`; use `put` instead.
- **CHANGED** `--get-config-path` option for `get` renamed to `--source-path`
- **FIXED** Automatic resolving of `--target-path` for `downsync` and `get` now resolved to a folder in the local directory