### PR TITLE
Update release workflow in GitHub Actions

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -34,11 +34,11 @@ jobs:
       - name: Check out source code
         uses: actions/checkout@v2
 
-      - name: Build ${{env.GITHUB_REF_NAME}}
+      - name: Build ${GITHUB_REF_NAME}
         run: |
           pushd ./cmd/longtail
-          echo Version ${{env.GITHUB_REF_NAME}}
-          go build -ldflags="-s -w -X 'github.com/DanEngelbrecht/golongtail/commands.BuildVersion=${{env.GITHUB_REF_NAME}}'" .
+          echo Version ${GITHUB_REF_NAME}
+          go build -ldflags="-s -w -X 'github.com/DanEngelbrecht/golongtail/commands.BuildVersion=${GITHUB_REF_NAME}'" .
           popd
 
       - name: build dist
@@ -116,7 +116,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: ${{env.GITHUB_REF_NAME}}
+        tag_name: ${GITHUB_REF_NAME}
         body: |
           ${{steps.read_changelog.outputs.contents}}
         draft: false

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -23,10 +23,8 @@ jobs:
       - name: build cmd
         run: |
           pushd ./cmd/longtail
-          GITHUB_FULLREF=${{ github.ref }}
-          RELEASE_VERSION=${GITHUB_FULLREF#refs/*/}
-          echo Version $RELEASE_VERSION
-          go build -ldflags="-s -w -X 'github.com/DanEngelbrecht/golongtail/commands.BuildVersion=${RELEASE_VERSION}'" .
+          echo Version ${{github.ref.name}}
+          go build -ldflags="-s -w -X 'github.com/DanEngelbrecht/golongtail/commands.BuildVersion=${{github.ref.name}}'" .
           popd
 
       - name: build dist
@@ -56,10 +54,8 @@ jobs:
       - name: build cmd
         run: |
           pushd ./cmd/longtail
-          GITHUB_FULLREF=${{ github.ref }}
-          RELEASE_VERSION=${GITHUB_FULLREF#refs/*/}
-          echo Version $RELEASE_VERSION
-          go build -ldflags="-s -w -X 'github.com/DanEngelbrecht/golongtail/commands.BuildVersion=${RELEASE_VERSION}'" .
+          echo Version ${{github.ref.name}}
+          go build -ldflags="-s -w -X 'github.com/DanEngelbrecht/golongtail/commands.BuildVersion=${{github.ref.name}}'" .
           popd
 
       - name: build dist
@@ -89,10 +85,8 @@ jobs:
       - name: build cmd
         run: |
           pushd ./cmd/longtail
-          $GITHUB_FULLREF="${{ github.ref }}"
-          $RELEASE_VERSION=$GITHUB_FULLREF -replace 'refs/.*/', ''
-          echo Version $RELEASE_VERSION
-          go build -ldflags="-s -w -X 'github.com/DanEngelbrecht/golongtail/commands.BuildVersion=${RELEASE_VERSION}'" .
+          echo Version ${{github.ref.name}}
+          go build -ldflags="-s -w -X 'github.com/DanEngelbrecht/golongtail/commands.BuildVersion=${{github.ref.name}}'" .
           popd
 
       - name: build dist
@@ -115,20 +109,7 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@master
-    - name: Create Release
-      id: create_release
-      uses: actions/create-release@latest
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
-      with:
-        tag_name: ${{ github.ref }}
-        name: Release ${{ github.ref }}
-        body: |
-          Changes in this Release
-          - **CHANGED** set block extension to ".lsb" for fsblockstore in remote stores
-          - **UPDATED** Updated longtail to 0.3.3
-        draft: false
-        prerelease: false
+
     - name: Download Linux artifacts
       uses: actions/download-artifact@v1
       with:
@@ -162,15 +143,36 @@ jobs:
       uses: montudor/action-zip@v0.1.0
       with:
         args: zip -qq -r ./win32-x64.zip ./dist-win32-x64
-    - name: Upload to GitHub release
-      uses: Roang-zero1/github-upload-release-artifacts-action@master
+
+    - name: Check prerelease
+      id: get-prerelease
+      uses: haya14busa/action-cond@v1
       with:
-        args: |
+        cond: ${{contains(github.ref, '-pre')}}
+        if_true: "true"
+        if_false: "false"
+
+    - name: Read CHANGELOG
+      id: read_changelog
+      uses: andstor/file-reader-action@v1
+      with:
+        path: "CHANGELOG.md"
+
+    - name: Create Release
+      id: create_release
+      uses: softprops/action-gh-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{github.ref.name}}
+        body: |
+          ${{steps.read_changelog.outputs.contents}}
+        draft: false
+        prerelease: ${{steps.get-prerelease.outputs.value}}
+        files: |
           win32-x64.zip
           linux-x64.zip
           macos-x64.zip
           longtail-linux-x64
           longtail-macos-x64
           longtail-win32-x64.exe
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -124,7 +124,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: ${{github.ref.name}]
+        tag_name: ${{github.ref.name}}
         body: |
           ${{steps.read_changelog.outputs.contents}}
         draft: false

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -128,7 +128,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: ${{github.ref.name}]
+        tag_name: ${{github.ref.name}}
         body: |
           ${{steps.read_changelog.outputs.contents}}
         draft: false

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -114,9 +114,9 @@ jobs:
 
     - name: Read CHANGELOG
       id: read_changelog
-      uses: andstor/file-reader-action@v1
-      with:
-        path: "CHANGELOG.md"
+      run: |
+        CONTENTS=$(sed '1p;1,/^##/!d;/##/d' CHANGELOG.md)
+        echo "::set-output name=contents::${CONTENTS}"
 
     - name: Create Release
       id: create_release

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -37,8 +37,9 @@ jobs:
       - name: Build ${GITHUB_REF_NAME}
         run: |
           pushd ./cmd/longtail
-          echo Version ${GITHUB_REF_NAME}
-          go build -ldflags="-s -w -X 'github.com/DanEngelbrecht/golongtail/commands.BuildVersion=${GITHUB_REF_NAME}'" .
+          echo github.ref.name ${{ github.ref.name }}
+          echo github.ref ${{ github.ref }}
+          go build -ldflags="-s -w -X 'github.com/DanEngelbrecht/golongtail/commands.BuildVersion=${{ github.ref.name }}'" .
           popd
 
       - name: build dist

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -34,11 +34,11 @@ jobs:
       - name: Check out source code
         uses: actions/checkout@v2
 
-      - name: Build ${{github.ref.name}}
+      - name: Build ${{env.GITHUB_REF_NAME}}
         run: |
           pushd ./cmd/longtail
-          echo Version ${{github.ref.name}}
-          go build -ldflags="-s -w -X 'github.com/DanEngelbrecht/golongtail/commands.BuildVersion=${{github.ref.name}}'" .
+          echo Version ${{env.GITHUB_REF_NAME}}
+          go build -ldflags="-s -w -X 'github.com/DanEngelbrecht/golongtail/commands.BuildVersion=${{env.GITHUB_REF_NAME}}'" .
           popd
 
       - name: build dist
@@ -116,7 +116,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: ${{github.ref.name}}
+        tag_name: ${{env.GITHUB_REF_NAME}}
         body: |
           ${{steps.read_changelog.outputs.contents}}
         draft: false

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -42,90 +42,90 @@ jobs:
           go build -ldflags="-s -w -X 'github.com/DanEngelbrecht/golongtail/commands.BuildVersion=${{ github.ref.name }}'" .
           popd
 
-      - name: build dist
-        run: |
-          mkdir dist
-          cp ${{matrix.target}} dist/
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@master
-        with:
-          name: dist-${{matrix.platform}}-x64
-          path: dist
-
-  create-release:
-
-    runs-on: ubuntu-18.04
-
-    needs: [build]
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@master
-
-    - name: Download Linux artifacts
-      uses: actions/download-artifact@v1
-      with:
-        name: dist-linux-x64
-        path: dist-linux-x64
-    - name: Download MacOs artifacts
-      uses: actions/download-artifact@v1
-      with:
-        name: dist-macos-x64
-        path: dist-macos-x64
-    - name: Download Win32 artifacts
-      uses: actions/download-artifact@v1
-      with:
-        name: dist-win32-x64
-        path: dist-win32-x64
-
-    - name: rename artifacts
-      run: |
-        cp dist-linux-x64/longtail longtail-linux-x64
-        cp dist-macos-x64/longtail longtail-macos-x64
-        cp dist-win32-x64/longtail.exe longtail-win32-x64.exe
-    - name: Zip Linux artifacts
-      uses: montudor/action-zip@v0.1.0
-      with:
-        args: zip -qq -r ./linux-x64.zip ./dist-linux-x64
-    - name: Zip MacOS artifacts
-      uses: montudor/action-zip@v0.1.0
-      with:
-        args: zip -qq -r ./macos-x64.zip ./dist-macos-x64
-    - name: Zip Win32 artifacts
-      uses: montudor/action-zip@v0.1.0
-      with:
-        args: zip -qq -r ./win32-x64.zip ./dist-win32-x64
-
-    - name: Check prerelease
-      id: get-prerelease
-      uses: haya14busa/action-cond@v1
-      with:
-        cond: ${{contains(github.ref, '-pre')}}
-        if_true: "true"
-        if_false: "false"
-
-    - name: Read CHANGELOG
-      id: read_changelog
-      uses: andstor/file-reader-action@v1
-      with:
-        path: "CHANGELOG.md"
-
-    - name: Create Release
-      id: create_release
-      uses: softprops/action-gh-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${GITHUB_REF_NAME}
-        body: |
-          ${{steps.read_changelog.outputs.contents}}
-        draft: false
-        prerelease: ${{steps.get-prerelease.outputs.value}}
-        files: |
-          win32-x64.zip
-          linux-x64.zip
-          macos-x64.zip
-          longtail-linux-x64
-          longtail-macos-x64
-          longtail-win32-x64.exe
+#      - name: build dist
+#        run: |
+#          mkdir dist
+#          cp ${{matrix.target}} dist/
+#
+#      - name: Upload artifacts
+#        uses: actions/upload-artifact@master
+#        with:
+#          name: dist-${{matrix.platform}}-x64
+#          path: dist
+#
+#  create-release:
+#
+#    runs-on: ubuntu-18.04
+#
+#    needs: [build]
+#
+#    steps:
+#    - name: Checkout code
+#      uses: actions/checkout@master
+#
+#    - name: Download Linux artifacts
+#      uses: actions/download-artifact@v1
+#      with:
+#        name: dist-linux-x64
+#        path: dist-linux-x64
+#    - name: Download MacOs artifacts
+#      uses: actions/download-artifact@v1
+#      with:
+#        name: dist-macos-x64
+#        path: dist-macos-x64
+#    - name: Download Win32 artifacts
+#      uses: actions/download-artifact@v1
+#      with:
+#        name: dist-win32-x64
+#        path: dist-win32-x64
+#
+#    - name: rename artifacts
+#      run: |
+#        cp dist-linux-x64/longtail longtail-linux-x64
+#        cp dist-macos-x64/longtail longtail-macos-x64
+#        cp dist-win32-x64/longtail.exe longtail-win32-x64.exe
+#    - name: Zip Linux artifacts
+#      uses: montudor/action-zip@v0.1.0
+#      with:
+#        args: zip -qq -r ./linux-x64.zip ./dist-linux-x64
+#    - name: Zip MacOS artifacts
+#      uses: montudor/action-zip@v0.1.0
+#      with:
+#        args: zip -qq -r ./macos-x64.zip ./dist-macos-x64
+#    - name: Zip Win32 artifacts
+#      uses: montudor/action-zip@v0.1.0
+#      with:
+#        args: zip -qq -r ./win32-x64.zip ./dist-win32-x64
+#
+#    - name: Check prerelease
+#      id: get-prerelease
+#      uses: haya14busa/action-cond@v1
+#      with:
+#        cond: ${{contains(github.ref, '-pre')}}
+#        if_true: "true"
+#        if_false: "false"
+#
+#    - name: Read CHANGELOG
+#      id: read_changelog
+#      uses: andstor/file-reader-action@v1
+#      with:
+#        path: "CHANGELOG.md"
+#
+#    - name: Create Release
+#      id: create_release
+#      uses: softprops/action-gh-release@v1
+#      env:
+#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#      with:
+#        tag_name: ${GITHUB_REF_NAME}
+#        body: |
+#          ${{steps.read_changelog.outputs.contents}}
+#        draft: false
+#        prerelease: ${{steps.get-prerelease.outputs.value}}
+#        files: |
+#          win32-x64.zip
+#          linux-x64.zip
+#          macos-x64.zip
+#          longtail-linux-x64
+#          longtail-macos-x64
+#          longtail-win32-x64.exe

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -7,40 +7,24 @@ on:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
 jobs:
-  build-linux:
+  build:
+    name: Build & Upload
 
-    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, macos-latest, windows-latest]
+        include:
+        - os: ubuntu-18.04
+          target: ./cmd/longtail/longtail
+          platform: linux
+        - os: macos-latest
+          target: ./cmd/longtail/longtail
+          platform: macos
+        - os: windows-latest
+          target: ./cmd/longtail/longtail.exe
+          platform: win32
 
-    steps:
-      - name: Set up Go 1.17.1
-        uses: actions/setup-go@v1
-        with:
-          go-version: 1.17.1
-
-      - name: Check out source code
-        uses: actions/checkout@v2
-
-      - name: build cmd
-        run: |
-          pushd ./cmd/longtail
-          echo Version ${{github.ref.name}}
-          go build -ldflags="-s -w -X 'github.com/DanEngelbrecht/golongtail/commands.BuildVersion=${{github.ref.name}}'" .
-          popd
-
-      - name: build dist
-        run: |
-          mkdir dist
-          cp ./cmd/longtail/longtail dist/
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@master
-        with:
-          name: dist-linux-x64
-          path: dist
-
-  build-macos:
-
-    runs-on: macos-latest
+    runs-on: ${{matrix.os}}
 
     steps:
       - name: Set up Go 1.17.1
@@ -51,7 +35,7 @@ jobs:
       - name: Check out source code
         uses: actions/checkout@v2
 
-      - name: build cmd
+      - name: Build ${{github.ref.name}}
         run: |
           pushd ./cmd/longtail
           echo Version ${{github.ref.name}}
@@ -61,43 +45,12 @@ jobs:
       - name: build dist
         run: |
           mkdir dist
-          cp ./cmd/longtail/longtail dist/
+          cp ${{matrix.os.target}} dist/
 
       - name: Upload artifacts
         uses: actions/upload-artifact@master
         with:
-          name: dist-macos-x64
-          path: dist
-
-  build-win32:
-
-    runs-on: windows-latest
-
-    steps:
-      - name: Set up Go 1.17.1
-        uses: actions/setup-go@v1
-        with:
-          go-version: 1.17.1
-
-      - name: Check out source code
-        uses: actions/checkout@v2
-
-      - name: build cmd
-        run: |
-          pushd ./cmd/longtail
-          echo Version ${{github.ref.name}}
-          go build -ldflags="-s -w -X 'github.com/DanEngelbrecht/golongtail/commands.BuildVersion=${{github.ref.name}}'" .
-          popd
-
-      - name: build dist
-        run: |
-          mkdir dist
-          cp ./cmd/longtail/longtail.exe dist/
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@master
-        with:
-          name: dist-win32-x64
+          name: dist-${{matrix.os.platform}}-x64
           path: dist
 
   create-release:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -112,10 +112,15 @@ jobs:
         if_true: "true"
         if_false: "false"
 
-    - name: Read CHANGELOG
-      id: read_changelog
+    - name: Extract Version Changes
       run: |
-        echo "CHANGELOG_CONTENTS=$(sed '1p;1,/^##/!d;/##/d' CHANGELOG.md)" >> $GITHUB_ENV
+        sed '1,/^##/!d;/##/d' CHANGELOG.md > CHANGELOG.tmp
+
+    - name: Read CHANGELOG.tmp
+      id: read_changelog
+      uses: andstor/file-reader-action@v1
+      with:
+        path: "CHANGELOG.tmp"
 
     - name: Create Release
       id: create_release
@@ -123,9 +128,9 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: ${{github.ref.name}}
+        tag_name: ${{github.ref.name}]
         body: |
-          ${{ env.CHANGELOG_CONTENTS }}
+          ${{steps.read_changelog.outputs.contents}}
         draft: false
         prerelease: ${{steps.get-prerelease.outputs.value}}
         files: |

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -44,90 +44,90 @@ jobs:
           go build -ldflags="-s -w -X 'github.com/DanEngelbrecht/golongtail/commands.BuildVersion=${{ matrix.tag }}'" .
           popd
 
-#      - name: build dist
-#        run: |
-#          mkdir dist
-#          cp ${{matrix.target}} dist/
-#
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@master
-#        with:
-#          name: dist-${{matrix.platform}}-x64
-#          path: dist
-#
-#  create-release:
-#
-#    runs-on: ubuntu-18.04
-#
-#    needs: [build]
-#
-#    steps:
-#    - name: Checkout code
-#      uses: actions/checkout@master
-#
-#    - name: Download Linux artifacts
-#      uses: actions/download-artifact@v1
-#      with:
-#        name: dist-linux-x64
-#        path: dist-linux-x64
-#    - name: Download MacOs artifacts
-#      uses: actions/download-artifact@v1
-#      with:
-#        name: dist-macos-x64
-#        path: dist-macos-x64
-#    - name: Download Win32 artifacts
-#      uses: actions/download-artifact@v1
-#      with:
-#        name: dist-win32-x64
-#        path: dist-win32-x64
-#
-#    - name: rename artifacts
-#      run: |
-#        cp dist-linux-x64/longtail longtail-linux-x64
-#        cp dist-macos-x64/longtail longtail-macos-x64
-#        cp dist-win32-x64/longtail.exe longtail-win32-x64.exe
-#    - name: Zip Linux artifacts
-#      uses: montudor/action-zip@v0.1.0
-#      with:
-#        args: zip -qq -r ./linux-x64.zip ./dist-linux-x64
-#    - name: Zip MacOS artifacts
-#      uses: montudor/action-zip@v0.1.0
-#      with:
-#        args: zip -qq -r ./macos-x64.zip ./dist-macos-x64
-#    - name: Zip Win32 artifacts
-#      uses: montudor/action-zip@v0.1.0
-#      with:
-#        args: zip -qq -r ./win32-x64.zip ./dist-win32-x64
-#
-#    - name: Check prerelease
-#      id: get-prerelease
-#      uses: haya14busa/action-cond@v1
-#      with:
-#        cond: ${{contains(github.ref, '-pre')}}
-#        if_true: "true"
-#        if_false: "false"
-#
-#    - name: Read CHANGELOG
-#      id: read_changelog
-#      uses: andstor/file-reader-action@v1
-#      with:
-#        path: "CHANGELOG.md"
-#
-#    - name: Create Release
-#      id: create_release
-#      uses: softprops/action-gh-release@v1
-#      env:
-#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#      with:
-#        tag_name: ${GITHUB_REF_NAME}
-#        body: |
-#          ${{steps.read_changelog.outputs.contents}}
-#        draft: false
-#        prerelease: ${{steps.get-prerelease.outputs.value}}
-#        files: |
-#          win32-x64.zip
-#          linux-x64.zip
-#          macos-x64.zip
-#          longtail-linux-x64
-#          longtail-macos-x64
-#          longtail-win32-x64.exe
+      - name: build dist
+        run: |
+          mkdir dist
+          cp ${{matrix.target}} dist/
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@master
+        with:
+          name: dist-${{matrix.platform}}-x64
+          path: dist
+
+  create-release:
+
+    runs-on: ubuntu-18.04
+
+    needs: [build]
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@master
+
+    - name: Download Linux artifacts
+      uses: actions/download-artifact@v1
+      with:
+        name: dist-linux-x64
+        path: dist-linux-x64
+    - name: Download MacOs artifacts
+      uses: actions/download-artifact@v1
+      with:
+        name: dist-macos-x64
+        path: dist-macos-x64
+    - name: Download Win32 artifacts
+      uses: actions/download-artifact@v1
+      with:
+        name: dist-win32-x64
+        path: dist-win32-x64
+
+    - name: rename artifacts
+      run: |
+        cp dist-linux-x64/longtail longtail-linux-x64
+        cp dist-macos-x64/longtail longtail-macos-x64
+        cp dist-win32-x64/longtail.exe longtail-win32-x64.exe
+    - name: Zip Linux artifacts
+      uses: montudor/action-zip@v0.1.0
+      with:
+        args: zip -qq -r ./linux-x64.zip ./dist-linux-x64
+    - name: Zip MacOS artifacts
+      uses: montudor/action-zip@v0.1.0
+      with:
+        args: zip -qq -r ./macos-x64.zip ./dist-macos-x64
+    - name: Zip Win32 artifacts
+      uses: montudor/action-zip@v0.1.0
+      with:
+        args: zip -qq -r ./win32-x64.zip ./dist-win32-x64
+
+    - name: Check prerelease
+      id: get-prerelease
+      uses: haya14busa/action-cond@v1
+      with:
+        cond: ${{contains(github.ref, '-pre')}}
+        if_true: "true"
+        if_false: "false"
+
+    - name: Read CHANGELOG
+      id: read_changelog
+      uses: andstor/file-reader-action@v1
+      with:
+        path: "CHANGELOG.md"
+
+    - name: Create Release
+      id: create_release
+      uses: softprops/action-gh-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${GITHUB_REF_NAME}
+        body: |
+          ${{steps.read_changelog.outputs.contents}}
+        draft: false
+        prerelease: ${{steps.get-prerelease.outputs.value}}
+        files: |
+          win32-x64.zip
+          linux-x64.zip
+          macos-x64.zip
+          longtail-linux-x64
+          longtail-macos-x64
+          longtail-win32-x64.exe

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -57,7 +57,7 @@ jobs:
 
     runs-on: ubuntu-18.04
 
-    needs: [build-linux, build-macos, build-win32]
+    needs: [build]
 
     steps:
     - name: Checkout code

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -16,12 +16,15 @@ jobs:
         - os: ubuntu-18.04
           target: "./cmd/longtail/longtail"
           platform: linux
+          tag: "${GITHUB_REF_NAME}"
         - os: macos-latest
           target: "./cmd/longtail/longtail"
           platform: macos
+          tag: "${GITHUB_REF_NAME}"
         - os: windows-latest
           target: "./cmd/longtail/longtail.exe"
           platform: win32
+          tag: "${env:GITHUB_REF_NAME}"
 
     runs-on: ${{matrix.os}}
 
@@ -34,12 +37,11 @@ jobs:
       - name: Check out source code
         uses: actions/checkout@v2
 
-      - name: Build ${GITHUB_REF_NAME}
+      - name: Build
         run: |
           pushd ./cmd/longtail
-          echo github.ref.name ${{ github.ref.name }}
-          echo github.ref ${{ github.ref }}
-          go build -ldflags="-s -w -X 'github.com/DanEngelbrecht/golongtail/commands.BuildVersion=${{ github.ref.name }}'" .
+          echo matrix.tag ${{ matrix.tag }}
+          go build -ldflags="-s -w -X 'github.com/DanEngelbrecht/golongtail/commands.BuildVersion=${{ matrix.tag }}'" .
           popd
 
 #      - name: build dist

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -115,8 +115,7 @@ jobs:
     - name: Read CHANGELOG
       id: read_changelog
       run: |
-        CONTENTS=$(sed '1p;1,/^##/!d;/##/d' CHANGELOG.md)
-        echo "::set-output name=contents::${CONTENTS}"
+        echo "CHANGELOG_CONTENTS=$(sed '1p;1,/^##/!d;/##/d' CHANGELOG.md)" >> $GITHUB_ENV
 
     - name: Create Release
       id: create_release
@@ -126,7 +125,7 @@ jobs:
       with:
         tag_name: ${{github.ref.name}}
         body: |
-          ${{steps.read_changelog.outputs.contents}}
+          ${{ env.CHANGELOG_CONTENTS }}
         draft: false
         prerelease: ${{steps.get-prerelease.outputs.value}}
         files: |

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -70,30 +70,35 @@ jobs:
       with:
         name: dist-linux-x64
         path: dist-linux-x64
+
     - name: Download MacOs artifacts
       uses: actions/download-artifact@v1
       with:
         name: dist-macos-x64
         path: dist-macos-x64
+
     - name: Download Win32 artifacts
       uses: actions/download-artifact@v1
       with:
         name: dist-win32-x64
         path: dist-win32-x64
 
-    - name: rename artifacts
+    - name: Rename artifacts
       run: |
         cp dist-linux-x64/longtail longtail-linux-x64
         cp dist-macos-x64/longtail longtail-macos-x64
         cp dist-win32-x64/longtail.exe longtail-win32-x64.exe
+
     - name: Zip Linux artifacts
       uses: montudor/action-zip@v0.1.0
       with:
         args: zip -qq -r ./linux-x64.zip ./dist-linux-x64
+
     - name: Zip MacOS artifacts
       uses: montudor/action-zip@v0.1.0
       with:
         args: zip -qq -r ./macos-x64.zip ./dist-macos-x64
+
     - name: Zip Win32 artifacts
       uses: montudor/action-zip@v0.1.0
       with:
@@ -119,7 +124,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: ${GITHUB_REF_NAME}
+        tag_name: ${{github.ref.name}]
         body: |
           ${{steps.read_changelog.outputs.contents}}
         draft: false

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -12,16 +12,15 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-latest, windows-latest]
         include:
         - os: ubuntu-18.04
-          target: ./cmd/longtail/longtail
+          target: "./cmd/longtail/longtail"
           platform: linux
         - os: macos-latest
-          target: ./cmd/longtail/longtail
+          target: "./cmd/longtail/longtail"
           platform: macos
         - os: windows-latest
-          target: ./cmd/longtail/longtail.exe
+          target: "./cmd/longtail/longtail.exe"
           platform: win32
 
     runs-on: ${{matrix.os}}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -44,12 +44,12 @@ jobs:
       - name: build dist
         run: |
           mkdir dist
-          cp ${{matrix.os.target}} dist/
+          cp ${{matrix.target}} dist/
 
       - name: Upload artifacts
         uses: actions/upload-artifact@master
         with:
-          name: dist-${{matrix.os.platform}}-x64
+          name: dist-${{matrix.platform}}-x64
           path: dist
 
   create-release:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -14,41 +14,41 @@ jobs:
       with:
         access_token: ${{ github.token }}
 
-#  test:
-#    name: Build & Test
-#
-#    strategy:
-#      matrix:
-#        os: [ubuntu-18.04, macos-latest, windows-latest]
-#
-#    runs-on: ${{matrix.os}}
-#
-#    steps:
-#      - name: Set up Go 1.17.1
-#        uses: actions/setup-go@v1
-#        with:
-#          go-version: 1.17.1
-#
-#      - name: Check out source code
-#        uses: actions/checkout@v2
-#
-#      - name: test
-#        run: |
-#          pushd ./longtaillib
-#          go test .
-#          popd
-#          pushd ./longtailstorelib
-#          go test .
-#          popd
-#          pushd ./commands
-#          go test .
-#          popd
-#          pushd ./remotestore
-#          go test .
-#          popd
-#
-#      - name: build cmd
-#        run: |
-#          pushd ./cmd/longtail
-#          go build .
-#          popd
+  test:
+    name: Build & Test
+
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, macos-latest, windows-latest]
+
+    runs-on: ${{matrix.os}}
+
+    steps:
+      - name: Set up Go 1.17.1
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.17.1
+
+      - name: Check out source code
+        uses: actions/checkout@v2
+
+      - name: test
+        run: |
+          pushd ./longtaillib
+          go test .
+          popd
+          pushd ./longtailstorelib
+          go test .
+          popd
+          pushd ./commands
+          go test .
+          popd
+          pushd ./remotestore
+          go test .
+          popd
+
+      - name: build cmd
+        run: |
+          pushd ./cmd/longtail
+          go build .
+          popd

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -14,41 +14,41 @@ jobs:
       with:
         access_token: ${{ github.token }}
 
-  test:
-    name: Build & Test
-
-    strategy:
-      matrix:
-        os: [ubuntu-18.04, macos-latest, windows-latest]
-
-    runs-on: ${{matrix.os}}
-
-    steps:
-      - name: Set up Go 1.17.1
-        uses: actions/setup-go@v1
-        with:
-          go-version: 1.17.1
-
-      - name: Check out source code
-        uses: actions/checkout@v2
-
-      - name: test
-        run: |
-          pushd ./longtaillib
-          go test .
-          popd
-          pushd ./longtailstorelib
-          go test .
-          popd
-          pushd ./commands
-          go test .
-          popd
-          pushd ./remotestore
-          go test .
-          popd
-
-      - name: build cmd
-        run: |
-          pushd ./cmd/longtail
-          go build .
-          popd
+#  test:
+#    name: Build & Test
+#
+#    strategy:
+#      matrix:
+#        os: [ubuntu-18.04, macos-latest, windows-latest]
+#
+#    runs-on: ${{matrix.os}}
+#
+#    steps:
+#      - name: Set up Go 1.17.1
+#        uses: actions/setup-go@v1
+#        with:
+#          go-version: 1.17.1
+#
+#      - name: Check out source code
+#        uses: actions/checkout@v2
+#
+#      - name: test
+#        run: |
+#          pushd ./longtaillib
+#          go test .
+#          popd
+#          pushd ./longtailstorelib
+#          go test .
+#          popd
+#          pushd ./commands
+#          go test .
+#          popd
+#          pushd ./remotestore
+#          go test .
+#          popd
+#
+#      - name: build cmd
+#        run: |
+#          pushd ./cmd/longtail
+#          go build .
+#          popd

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,17 @@
+##
+
 - **UPDATED** Update all Go dependencies to latest version
 - **FIX** Simplified release workflow
 - **CHANGED** Read CHANGELOG.md when creating a release
 - **CHANGED** Automatically detect pre-release base on tag name (-preX suffix)
+
+## v0.3.3
+- **CHANGED** set block extension to ".lsb" for fsblockstore in remote stores
+- **UPDATED** Updated longtail to 0.3.3
+
+## v0.3.2
+- **ADDED** `put` commmand to complement `get` commmand
+- **CHANGED** `--get-config-path` option has been removed from `upsync`; use `put` instead.
+- **CHANGED** `--get-config-path` option for `get` renamed to `--source-path`
+- **FIXED** Automatic resolving of `--target-path` for `downsync` and `get` now resolves to a folder in the local directory
+- **UPDATED** Updated longtail to 0.3.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,4 @@
 ##
-
 - **UPDATED** Update all Go dependencies to latest version
 - **FIX** Simplified release workflow
 - **CHANGED** Read CHANGELOG.md when creating a release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+- **UPDATED** Update all Go dependencies to latest version
+- **FIX** Simplified release workflow
+- **CHANGED** Read CHANGELOG.md when creating a release
+- **CHANGED** Automatically detect pre-release base on tag name (-preX suffix)


### PR DESCRIPTION
- **FIX** Simplified release workflow
- **CHANGED** Read CHANGELOG.md when creating a release
- **CHANGED** Automatically detect pre-release base on tag name (-preX suffix)