### PR TITLE
Fix store index size

### DIFF
--- a/longtaillib/longtaillib.go
+++ b/longtaillib/longtaillib.go
@@ -1848,7 +1848,9 @@ func WriteStoreIndexToBuffer(index Longtail_StoreIndex) ([]byte, error) {
 		return nil, errors.Wrap(errnoToError(errno), fname)
 	}
 	defer C.Longtail_Free(buffer)
-	bytes := C.GoBytes(buffer, C.int(size))
+	unsafeBuffer := unsafe.Slice((*byte)(buffer), size)
+	bytes := make([]byte, size)
+	copy(bytes, unsafeBuffer)
 	return bytes, nil
 }
 

--- a/longtaillib/longtaillib_test.go
+++ b/longtaillib/longtaillib_test.go
@@ -677,7 +677,7 @@ func TestPutGetStoredBlock(t *testing.T) {
 
 	stats, err := blockStoreProxy.GetStats()
 	if err != nil {
-		t.Errorf("TestPutGetStoredBlock() GetStats() %wd", err)
+		t.Errorf("TestPutGetStoredBlock() GetStats() %d", err)
 	}
 	if stats.StatU64[Longtail_BlockStoreAPI_StatU64_GetStoredBlock_Count] != 1 {
 		t.Errorf("TestPutGetStoredBlock() stats.BlocksGetCount %d != %d", stats.StatU64[Longtail_BlockStoreAPI_StatU64_GetStoredBlock_Count], 1)


### PR DESCRIPTION
This attempts to use `unsafe.Slice` instead of `C.GoBytes` in order to avoid size to C.int conversion.
Ref: https://github.com/golang/go/wiki/cgo#turning-c-arrays-into-go-slices