### PR TITLE
Add NativeBuffer to avoid copying of bytes to Golang array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ##
-- **FIXED** Full support for windows extended length paths (UNC paths)
+- **CHANGED** Add NativeBuffer to avoid copying of bytes to Golang array and remove signed 32-bit integer length of arrays (`WriteStoredBlockToBuffer`, `WriteBlockIndexToBuffer`, `WriteVersionIndexToBuffer`, `WriteStoreIndexToBuffer`)
+- **FIXED** Full support for windows extended length paths (fixes: UNC path may not contain forward slashes (#214))
 
 ## v0.3.5
 - **UPDATED** Updated longtail to 0.3.4

--- a/commands/cmd_clonestore_test.go
+++ b/commands/cmd_clonestore_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/DanEngelbrecht/golongtail/longtailstorelib"
 	"github.com/DanEngelbrecht/golongtail/longtailutils"
+
 	"github.com/pkg/errors"
 )
 

--- a/commands/cmd_createversionstoreindex.go
+++ b/commands/cmd_createversionstoreindex.go
@@ -75,7 +75,8 @@ func createVersionStoreIndex(
 		err = errors.Wrapf(err, "Cant serialize store index for `%s`", sourceFilePath)
 		return storeStats, timeStats, errors.Wrap(err, fname)
 	}
-	err = longtailutils.WriteToURI(versionLocalStoreIndexPath, versionLocalStoreIndexBuffer, longtailutils.WithS3EndpointResolverURI(s3EndpointResolverURI))
+	defer versionLocalStoreIndexBuffer.Dispose()
+	err = longtailutils.WriteToURI(versionLocalStoreIndexPath, versionLocalStoreIndexBuffer.ToBuffer(), longtailutils.WithS3EndpointResolverURI(s3EndpointResolverURI))
 	if err != nil {
 		return storeStats, timeStats, errors.Wrap(err, fname)
 	}

--- a/commands/cmd_initremotestore_test.go
+++ b/commands/cmd_initremotestore_test.go
@@ -69,8 +69,10 @@ func TestInitRemoteStore(t *testing.T) {
 
 	storeIndexObject.Delete()
 	emptyStoreIndex, _ := longtaillib.CreateStoreIndexFromBlocks([]longtaillib.Longtail_BlockIndex{})
+	defer emptyStoreIndex.Dispose()
 	emptyStoreIndexBytes, _ := longtaillib.WriteStoreIndexToBuffer(emptyStoreIndex)
-	storeIndexObject.Write(emptyStoreIndexBytes)
+	defer emptyStoreIndexBytes.Dispose()
+	storeIndexObject.Write(emptyStoreIndexBytes.ToBuffer())
 
 	// Force rebuilding the index even though it exists
 	cmd, err = executeCommandLine("init-remote-store", "--storage-uri", fsBlobPathPrefix+"/storage")

--- a/commands/cmd_prunestore.go
+++ b/commands/cmd_prunestore.go
@@ -114,12 +114,13 @@ func pruneOne(
 
 	if versionLocalStoreIndexFilePath != "" && writeVersionLocalStoreIndex && !dryRun {
 		sbuffer, err := longtaillib.WriteStoreIndexToBuffer(existingStoreIndex)
+		defer sbuffer.Dispose()
 		if err != nil {
 			existingStoreIndex.Dispose()
 			result.err = errors.Wrap(err, fname)
 			return
 		}
-		err = longtailutils.WriteToURI(versionLocalStoreIndexFilePath, sbuffer, longtailutils.WithS3EndpointResolverURI(s3EndpointResolverURI))
+		err = longtailutils.WriteToURI(versionLocalStoreIndexFilePath, sbuffer.ToBuffer(), longtailutils.WithS3EndpointResolverURI(s3EndpointResolverURI))
 		if err != nil {
 			existingStoreIndex.Dispose()
 			result.err = errors.Wrap(err, fname)

--- a/commands/cmd_prunestore_index.go
+++ b/commands/cmd_prunestore_index.go
@@ -75,7 +75,8 @@ func pruneOneUsingStoreIndex(
 			result.err = errors.Wrap(err, fname)
 			return
 		}
-		err = longtailutils.WriteToURI(versionLocalStoreIndexFilePath, sbuffer, longtailutils.WithS3EndpointResolverURI(s3EndpointResolverURI))
+		defer sbuffer.Dispose()
+		err = longtailutils.WriteToURI(versionLocalStoreIndexFilePath, sbuffer.ToBuffer(), longtailutils.WithS3EndpointResolverURI(s3EndpointResolverURI))
 		if err != nil {
 			existingStoreIndex.Dispose()
 			result.err = errors.Wrap(err, fname)
@@ -329,11 +330,12 @@ func pruneStoreIndex(
 
 	writeStoreIndexStartTime := time.Now()
 	prunedStoreIndexBuffer, err := longtaillib.WriteStoreIndexToBuffer(prunedStoreIndex)
+	defer prunedStoreIndexBuffer.Dispose()
 	prunedStoreIndex.Dispose()
 	if err != nil {
 		return storeStats, timeStats, errors.Wrap(err, fname)
 	}
-	err = longtailutils.WriteToURI(storeIndexPath, prunedStoreIndexBuffer, longtailutils.WithS3EndpointResolverURI(s3EndpointResolverURI))
+	err = longtailutils.WriteToURI(storeIndexPath, prunedStoreIndexBuffer.ToBuffer(), longtailutils.WithS3EndpointResolverURI(s3EndpointResolverURI))
 	timeStats = append(timeStats, longtailutils.TimeStat{"Write store index", time.Since(writeStoreIndexStartTime)})
 	if err != nil {
 		return storeStats, timeStats, errors.Wrap(err, fname)

--- a/commands/cmd_upsync.go
+++ b/commands/cmd_upsync.go
@@ -190,8 +190,9 @@ func upsync(
 		err = errors.Wrapf(err, "Failed serializing version index for `%s`", targetFilePath)
 		return storeStats, timeStats, errors.Wrapf(err, fname)
 	}
+	defer vbuffer.Dispose()
 
-	err = longtailutils.WriteToURI(targetFilePath, vbuffer, longtailutils.WithS3EndpointResolverURI(s3EndpointResolverURI))
+	err = longtailutils.WriteToURI(targetFilePath, vbuffer.ToBuffer(), longtailutils.WithS3EndpointResolverURI(s3EndpointResolverURI))
 	if err != nil {
 		return storeStats, timeStats, errors.Wrapf(err, fname)
 	}
@@ -207,11 +208,12 @@ func upsync(
 		}
 		defer versionLocalStoreIndex.Dispose()
 		versionLocalStoreIndexBuffer, err := longtaillib.WriteStoreIndexToBuffer(versionLocalStoreIndex)
+		defer versionLocalStoreIndexBuffer.Dispose()
 		if err != nil {
 			err = errors.Wrapf(err, "Failed serializing store index for `%s`", versionLocalStoreIndexPath)
 			return storeStats, timeStats, errors.Wrapf(err, fname)
 		}
-		err = longtailutils.WriteToURI(versionLocalStoreIndexPath, versionLocalStoreIndexBuffer, longtailutils.WithS3EndpointResolverURI(s3EndpointResolverURI))
+		err = longtailutils.WriteToURI(versionLocalStoreIndexPath, versionLocalStoreIndexBuffer.ToBuffer(), longtailutils.WithS3EndpointResolverURI(s3EndpointResolverURI))
 		if err != nil {
 			return storeStats, timeStats, errors.Wrapf(err, fname)
 		}

--- a/longtaillib/longtaillib.go
+++ b/longtaillib/longtaillib.go
@@ -1277,7 +1277,8 @@ func WriteStoredBlockToBuffer(storedBlock Longtail_StoredBlock) ([]byte, error) 
 		return nil, errors.Wrap(errnoToError(errno), fname)
 	}
 	defer C.Longtail_Free(buffer)
-	bytes := C.GoBytes(buffer, C.int(size))
+	bytes := make([]byte, size)
+	copy(bytes, unsafe.Slice((*byte)(buffer), size))
 	return bytes, nil
 }
 
@@ -1551,7 +1552,8 @@ func WriteBlockIndexToBuffer(index Longtail_BlockIndex) ([]byte, error) {
 		return nil, errors.Wrap(errnoToError(errno), fname)
 	}
 	defer C.Longtail_Free(buffer)
-	bytes := C.GoBytes(buffer, C.int(size))
+	bytes := make([]byte, size)
+	copy(bytes, unsafe.Slice((*byte)(buffer), size))
 	return bytes, nil
 }
 
@@ -1638,7 +1640,8 @@ func WriteVersionIndexToBuffer(index Longtail_VersionIndex) ([]byte, error) {
 		return nil, errors.Wrap(errnoToError(errno), fname)
 	}
 	defer C.Longtail_Free(buffer)
-	bytes := C.GoBytes(buffer, C.int(size))
+	bytes := make([]byte, size)
+	copy(bytes, unsafe.Slice((*byte)(buffer), size))
 	return bytes, nil
 }
 
@@ -1848,7 +1851,8 @@ func WriteStoreIndexToBuffer(index Longtail_StoreIndex) ([]byte, error) {
 		return nil, errors.Wrap(errnoToError(errno), fname)
 	}
 	defer C.Longtail_Free(buffer)
-	bytes := C.GoBytes(buffer, C.int(size))
+	bytes := make([]byte, size)
+	copy(bytes, unsafe.Slice((*byte)(buffer), size))
 	return bytes, nil
 }
 

--- a/longtaillib/longtaillib_test.go
+++ b/longtaillib/longtaillib_test.go
@@ -213,7 +213,8 @@ func validateStoredBlock(t *testing.T, storedBlock Longtail_StoredBlock, hashIde
 	blockIndex := storedBlock.GetBlockIndex()
 
 	b, _ := WriteBlockIndexToBuffer(blockIndex)
-	bi2, _ := ReadBlockIndexFromBuffer(b)
+	defer b.Dispose()
+	bi2, _ := ReadBlockIndexFromBuffer(b.ToBuffer())
 	bi2.Dispose()
 
 	if blockIndex.GetHashIdentifier() != hashIdentifier {
@@ -301,9 +302,10 @@ func Test_ReadWriteStoredBlockBuffer(t *testing.T) {
 	if err != nil {
 		t.Errorf("WriteStoredBlockToBuffer() %s", err)
 	}
+	defer storedBlockData.Dispose()
 	originalBlock.Dispose()
 
-	copyBlock, err := ReadStoredBlockFromBuffer(storedBlockData)
+	copyBlock, err := ReadStoredBlockFromBuffer(storedBlockData.ToBuffer())
 
 	if err != nil {
 		t.Errorf("InitStoredBlockFromData() %s", err)
@@ -965,7 +967,8 @@ func TestWriteContent(t *testing.T) {
 	}
 
 	b, _ := WriteVersionIndexToBuffer(versionIndex)
-	v2, _ := ReadVersionIndexFromBuffer(b)
+	defer b.Dispose()
+	v2, _ := ReadVersionIndexFromBuffer(b.ToBuffer())
 	v2.Dispose()
 
 	getExistingContentComplete := &testGetExistingContentCompletionAPI{}
@@ -1224,10 +1227,11 @@ func TestChangeVersion(t *testing.T) {
 	defer existingStoreIndex.Dispose()
 
 	b, err := WriteStoreIndexToBuffer(existingStoreIndex)
+	defer b.Dispose()
 	if err != nil {
 		t.Errorf("TestChangeVersion() WriteStoreIndexToBuffer() %s", err)
 	}
-	si2, err := ReadStoreIndexFromBuffer(b)
+	si2, err := ReadStoreIndexFromBuffer(b.ToBuffer())
 	if err != nil {
 		t.Errorf("TestChangeVersion() ReadStoreIndexFromBuffer() %s", err)
 	}

--- a/longtailstorelib/memblobstore.go
+++ b/longtailstorelib/memblobstore.go
@@ -122,13 +122,16 @@ func (blobObject *memBlobObject) Write(data []byte) (bool, error) {
 		}
 	}
 
+	dataCopy := make([]byte, len(data))
+	copy(dataCopy, data)
+
 	if !exists {
-		blob = &memBlob{generation: 0, path: blobObject.path, data: data}
+		blob = &memBlob{generation: 0, path: blobObject.path, data: dataCopy}
 		blobObject.client.store.blobs[blobObject.path] = blob
 		return true, nil
 	}
 
-	blob.data = data
+	blob.data = dataCopy
 	blob.generation++
 	return true, nil
 }

--- a/remotestore/remotestore_test.go
+++ b/remotestore/remotestore_test.go
@@ -392,6 +392,7 @@ func createStoredBlock(chunkCount uint32, hashIdentifier uint32) (longtaillib.Lo
 
 func storeBlock(blobClient longtailstorelib.BlobClient, storedBlock longtaillib.Longtail_StoredBlock, blockHashOffset uint64, parentPath string) uint64 {
 	bytes, _ := longtaillib.WriteStoredBlockToBuffer(storedBlock)
+	defer bytes.Dispose()
 	blockIndex := storedBlock.GetBlockIndex()
 	storedBlockHash := blockIndex.GetBlockHash() + blockHashOffset
 	path := getBlockPath("chunks", storedBlockHash)
@@ -399,7 +400,7 @@ func storeBlock(blobClient longtailstorelib.BlobClient, storedBlock longtaillib.
 		path = parentPath + "/" + path
 	}
 	blobObject, _ := blobClient.NewObject(path)
-	blobObject.Write(bytes)
+	blobObject.Write(bytes.ToBuffer())
 	return storedBlockHash
 }
 


### PR DESCRIPTION
- **CHANGED** Add NativeBuffer to avoid copying of bytes to Golang array and remove signed 32-bit integer length of arrays (`WriteStoredBlockToBuffer`, `WriteBlockIndexToBuffer`, `WriteVersionIndexToBuffer`, `WriteStoreIndexToBuffer`)