### PR TITLE
Improved logging support with log to file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 ##
+- **ADDED** `--log-to-console` option, default is on, disable all logging output in console with `--no-log-to-console`
+- **ADDED** `--log-file-path` option, default is no log file output, add path to json formatted log file
+- **ADDED** `--log-coloring` option, enables colored logging output in console, default is non-colored
+- **ADDED** `--log-console-timestamp` option, enabled timestamps in the console log, default is not to include time stamp
+- **CHANGED** Stats output is not printed to StdOut and with formatted logging to log file if enabled
+- **CHANGED** All logging now goes through logrus with the default logrus text formatting
+- **CHANGED** Progress output in console now goes to StdOut instead of StdErr
 - **CHANGED** Add NativeBuffer to avoid copying of bytes to Golang array and remove signed 32-bit integer length of arrays (`WriteStoredBlockToBuffer`, `WriteBlockIndexToBuffer`, `WriteVersionIndexToBuffer`, `WriteStoreIndexToBuffer`)
 - **FIXED** Full support for windows extended length paths (fixes: UNC path may not contain forward slashes (#214))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - **ADDED** `--log-file-path` option, default is no log file output, add path to json formatted log file
 - **ADDED** `--log-coloring` option, enables colored logging output in console, default is non-colored
 - **ADDED** `--log-console-timestamp` option, enabled timestamps in the console log, default is not to include time stamp
-- **CHANGED** Stats output is not printed to StdOut and with formatted logging to log file if enabled
+- **CHANGED** Stats output is now printed to StdOut and with formatted logging to log file if `--log-file-path` is enabled
 - **CHANGED** All logging now goes through logrus with the default logrus text formatting
 - **CHANGED** Progress output in console now goes to StdOut instead of StdErr
 - **CHANGED** Add NativeBuffer to avoid copying of bytes to Golang array and remove signed 32-bit integer length of arrays (`WriteStoredBlockToBuffer`, `WriteBlockIndexToBuffer`, `WriteVersionIndexToBuffer`, `WriteStoreIndexToBuffer`)

--- a/cmd/longtail/main.go
+++ b/cmd/longtail/main.go
@@ -112,6 +112,7 @@ func runCommand() error {
 				if l == "" {
 					continue
 				}
+				logrus.WithField("mem", l).Infof("stats")
 				fmt.Printf("[MEM] %s\n", l)
 			}
 			longtaillib.DisableMemtrace()

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -9,6 +9,10 @@ var Cli struct {
 	MemTraceDetailed        bool                       `name:"mem-trace-detailed" help:"Output detailed memory statistics from longtail"`
 	MemTraceCSV             string                     `name:"mem-trace-csv" help:"Output path for detailed memory statistics from longtail in csv format"`
 	WorkerCount             int                        `name:"worker-count" help:"Limit number of workers created, defaults to match number of logical CPUs (zero for default count)" default:"0"`
+	LogToConsole            bool                       `name:"log-to-console" help:"Enable logging to console" default:"true" negatable:""`
+	LogFilePath             string                     `name:"log-file-path" help:"Path to log file for json formatted logging"`
+	LogColoring             bool                       `name:"log-coloring" help:"Use colored logging for stdout"`
+	LogConsoleTimestamp     bool                       `name:"log-console-timestamp" help:"Add timestamps to stdout logging"`
 	Upsync                  UpsyncCmd                  `cmd:"" name:"upsync" help:"Upload a folder"`
 	Downsync                DownsyncCmd                `cmd:"" name:"downsync" help:"Download a folder"`
 	Get                     GetCmd                     `cmd:"" name:"get" help:"Download a folder using a get-config"`

--- a/longtailutils/debug.go
+++ b/longtailutils/debug.go
@@ -3,33 +3,46 @@ package longtailutils
 import (
 	"fmt"
 	"log"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/DanEngelbrecht/golongtail/longtaillib"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 // LoggerData ...
 type LoggerData struct {
 }
 
-var logLevelNames = [...]string{"DEBUG", "INFO", "WARNING", "ERROR", "OFF"}
-
 // OnLog ...
 func (l *LoggerData) OnLog(file string, function string, line int, level int, logFields []longtaillib.LogField, message string) {
-	var b strings.Builder
-	b.Grow(32 + len(message))
-	fmt.Fprintf(&b, "{")
-	fmt.Fprintf(&b, "\"file\": \"%s\"", file)
-	fmt.Fprintf(&b, ", \"func\": \"%s\"", function)
-	fmt.Fprintf(&b, ", \"line\": \"%d\"", line)
-	fmt.Fprintf(&b, ", \"level\": \"%s\"", logLevelNames[level])
+
+	fields := make(map[string]interface{})
 	for _, field := range logFields {
-		fmt.Fprintf(&b, ", \"%s\": \"%s\"", field.Name, field.Value)
+		fields[field.Name] = field.Value
 	}
-	fmt.Fprintf(&b, ", \"msg\": \"%s\"", message)
-	fmt.Fprintf(&b, "}")
-	log.Printf("%s", b.String())
+	fields["file"] = file
+	fields["func"] = function
+	fields["line"] = line
+
+	log := logrus.WithFields(fields)
+
+	switch level {
+	case 0:
+		log.WithFields(fields).Debug(message)
+	case 1:
+		log.WithFields(fields).Info(message)
+	case 2:
+		log.WithFields(fields).Warning(message)
+	case 3:
+		log.WithFields(fields).Error(message)
+	case 4:
+		break
+	}
+
+	//log.Printf("%s", b.String())
 }
 
 func ParseLevel(lvl string) (int, error) {
@@ -56,5 +69,49 @@ type AssertData struct {
 
 // OnAssert ...
 func (a *AssertData) OnAssert(expression string, file string, line int) {
-	log.Fatalf("ASSERT: %s %s:%d", expression, file, line)
+	logrus.Fatalf("ASSERT: %s %s:%d", expression, file, line)
+}
+
+type FileHook struct {
+	path      string
+	formatter logrus.Formatter
+	fd        *os.File
+}
+
+func NewFileLog(path string, formatter logrus.Formatter) (FileHook, error) {
+	dir := filepath.Dir(path)
+	os.MkdirAll(dir, os.ModePerm)
+	fd, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
+	if err != nil {
+		logrus.Println("failed to open logfile:", path, err)
+		return FileHook{}, err
+	}
+	return FileHook{path: path, formatter: formatter, fd: fd}, nil
+}
+
+func (hook *FileHook) Fire(entry *logrus.Entry) error {
+	msg, err := hook.formatter.Format(entry)
+
+	if err != nil {
+		log.Println("failed to generate string for entry:", err)
+		return err
+	}
+	_, err = hook.fd.Write(msg)
+	if err != nil {
+		log.Println("failed to write string to log file:", err)
+		return err
+	}
+	return hook.fd.Sync()
+}
+
+func (hook *FileHook) Levels() []logrus.Level {
+	return []logrus.Level{
+		logrus.TraceLevel,
+		logrus.DebugLevel,
+		logrus.InfoLevel,
+		logrus.WarnLevel,
+		logrus.ErrorLevel,
+		logrus.FatalLevel,
+		logrus.PanicLevel,
+	}
 }

--- a/longtailutils/progress.go
+++ b/longtailutils/progress.go
@@ -3,7 +3,6 @@ package longtailutils
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -55,8 +54,7 @@ func (p *ProgressData) OnProgress(totalCount uint32, doneCount uint32) {
 
 	timeString := fmt.Sprintf("%s%s", elapsed, etaString)
 
-	fmt.Fprintf(os.Stderr,
-		"\r%s %3d%%: |%s%s|: [%s]        %s",
+	fmt.Printf("\r%s %3d%%: |%s%s|: [%s]        %s",
 		p.task,
 		percentDone,
 		strings.Repeat("█", progressBarCount), strings.Repeat(" ", progressBarFullLength-progressBarCount),

--- a/longtailutils/stats.go
+++ b/longtailutils/stats.go
@@ -2,11 +2,11 @@ package longtailutils
 
 import (
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
 	"github.com/DanEngelbrecht/golongtail/longtaillib"
+	"github.com/sirupsen/logrus"
 )
 
 type TimeStat struct {
@@ -106,27 +106,51 @@ func GetDetailsString(path string, size uint64, permissions uint16, isDir bool, 
 	return fmt.Sprintf("%s %s %s", bits, sizeString, path)
 }
 
-func PrintStats(name string, stats longtaillib.BlockStoreStats) {
-	log.Printf("%s:\n", name)
-	log.Printf("------------------\n")
-	log.Printf("GetStoredBlock_Count:          %s\n", ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_GetStoredBlock_Count]))
-	log.Printf("GetStoredBlock_RetryCount:     %s\n", ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_GetStoredBlock_RetryCount]))
-	log.Printf("GetStoredBlock_FailCount:      %s\n", ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_GetStoredBlock_FailCount]))
-	log.Printf("GetStoredBlock_Chunk_Count:    %s\n", ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_GetStoredBlock_Chunk_Count]))
-	log.Printf("GetStoredBlock_Byte_Count:     %s\n", ByteCountBinary(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_GetStoredBlock_Byte_Count]))
-	log.Printf("PutStoredBlock_Count:          %s\n", ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_PutStoredBlock_Count]))
-	log.Printf("PutStoredBlock_RetryCount:     %s\n", ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_PutStoredBlock_RetryCount]))
-	log.Printf("PutStoredBlock_FailCount:      %s\n", ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_PutStoredBlock_FailCount]))
-	log.Printf("PutStoredBlock_Chunk_Count:    %s\n", ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_PutStoredBlock_Chunk_Count]))
-	log.Printf("PutStoredBlock_Byte_Count:     %s\n", ByteCountBinary(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_PutStoredBlock_Byte_Count]))
-	log.Printf("GetExistingContent_Count:      %s\n", ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_GetExistingContent_Count]))
-	log.Printf("GetExistingContent_RetryCount: %s\n", ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_GetExistingContent_RetryCount]))
-	log.Printf("GetExistingContent_FailCount:  %s\n", ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_GetExistingContent_FailCount]))
-	log.Printf("PreflightGet_Count:            %s\n", ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_PreflightGet_Count]))
-	log.Printf("PreflightGet_RetryCount:       %s\n", ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_PreflightGet_RetryCount]))
-	log.Printf("PreflightGet_FailCount:        %s\n", ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_PreflightGet_FailCount]))
-	log.Printf("Flush_Count:                   %s\n", ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_Flush_Count]))
-	log.Printf("Flush_FailCount:               %s\n", ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_Flush_FailCount]))
-	log.Printf("GetStats_Count:                %s\n", ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_GetStats_Count]))
-	log.Printf("------------------\n")
+func PrintStats(name string, stats longtaillib.BlockStoreStats, showStats bool) {
+	if showStats {
+		fmt.Printf("%s:\n", name)
+		fmt.Printf("------------------\n")
+		fmt.Printf("GetStoredBlock_Count:          %s\n", ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_GetStoredBlock_Count]))
+		fmt.Printf("GetStoredBlock_RetryCount:     %s\n", ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_GetStoredBlock_RetryCount]))
+		fmt.Printf("GetStoredBlock_FailCount:      %s\n", ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_GetStoredBlock_FailCount]))
+		fmt.Printf("GetStoredBlock_Chunk_Count:    %s\n", ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_GetStoredBlock_Chunk_Count]))
+		fmt.Printf("GetStoredBlock_Byte_Count:     %s\n", ByteCountBinary(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_GetStoredBlock_Byte_Count]))
+		fmt.Printf("PutStoredBlock_Count:          %s\n", ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_PutStoredBlock_Count]))
+		fmt.Printf("PutStoredBlock_RetryCount:     %s\n", ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_PutStoredBlock_RetryCount]))
+		fmt.Printf("PutStoredBlock_FailCount:      %s\n", ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_PutStoredBlock_FailCount]))
+		fmt.Printf("PutStoredBlock_Chunk_Count:    %s\n", ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_PutStoredBlock_Chunk_Count]))
+		fmt.Printf("PutStoredBlock_Byte_Count:     %s\n", ByteCountBinary(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_PutStoredBlock_Byte_Count]))
+		fmt.Printf("GetExistingContent_Count:      %s\n", ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_GetExistingContent_Count]))
+		fmt.Printf("GetExistingContent_RetryCount: %s\n", ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_GetExistingContent_RetryCount]))
+		fmt.Printf("GetExistingContent_FailCount:  %s\n", ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_GetExistingContent_FailCount]))
+		fmt.Printf("PreflightGet_Count:            %s\n", ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_PreflightGet_Count]))
+		fmt.Printf("PreflightGet_RetryCount:       %s\n", ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_PreflightGet_RetryCount]))
+		fmt.Printf("PreflightGet_FailCount:        %s\n", ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_PreflightGet_FailCount]))
+		fmt.Printf("Flush_Count:                   %s\n", ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_Flush_Count]))
+		fmt.Printf("Flush_FailCount:               %s\n", ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_Flush_FailCount]))
+		fmt.Printf("GetStats_Count:                %s\n", ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_GetStats_Count]))
+		fmt.Printf("------------------\n")
+	}
+	logrus.WithFields(logrus.Fields{
+		"Store":                         name,
+		"GetStoredBlock_Count":          ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_GetStoredBlock_Count]),
+		"GetStoredBlock_RetryCount":     ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_GetStoredBlock_RetryCount]),
+		"GetStoredBlock_FailCount":      ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_GetStoredBlock_FailCount]),
+		"GetStoredBlock_Chunk_Count":    ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_GetStoredBlock_Chunk_Count]),
+		"GetStoredBlock_Byte_Count":     ByteCountBinary(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_GetStoredBlock_Byte_Count]),
+		"PutStoredBlock_Count":          ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_PutStoredBlock_Count]),
+		"PutStoredBlock_RetryCount":     ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_PutStoredBlock_RetryCount]),
+		"PutStoredBlock_FailCount":      ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_PutStoredBlock_FailCount]),
+		"PutStoredBlock_Chunk_Count":    ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_PutStoredBlock_Chunk_Count]),
+		"PutStoredBlock_Byte_Count":     ByteCountBinary(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_PutStoredBlock_Byte_Count]),
+		"GetExistingContent_Count":      ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_GetExistingContent_Count]),
+		"GetExistingContent_RetryCount": ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_GetExistingContent_RetryCount]),
+		"GetExistingContent_FailCount":  ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_GetExistingContent_FailCount]),
+		"PreflightGet_Count":            ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_PreflightGet_Count]),
+		"PreflightGet_RetryCount":       ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_PreflightGet_RetryCount]),
+		"PreflightGet_FailCount":        ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_PreflightGet_FailCount]),
+		"Flush_Count":                   ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_Flush_Count]),
+		"Flush_FailCount":               ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_Flush_FailCount]),
+		"GetStats_Count":                ByteCountDecimal(stats.StatU64[longtaillib.Longtail_BlockStoreAPI_StatU64_GetStats_Count]),
+	}).Printf("store stats")
 }

--- a/remotestore/remotestore.go
+++ b/remotestore/remotestore.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
-	"log"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -1083,13 +1082,13 @@ func (s *remoteStore) Close() {
 	for i := 0; i < s.workerCount; i++ {
 		err := <-s.workerErrorChan
 		if err != nil {
-			log.Fatal(err)
+			logrus.Fatal(err)
 		}
 	}
 	close(s.blockIndexChan)
 	err := <-s.workerErrorChan
 	if err != nil {
-		log.Fatal(err)
+		logrus.Fatal(err)
 	}
 
 	s.defaultClient.Close()


### PR DESCRIPTION
- **ADDED** `--log-to-console` option, default is on, disable all logging output in console with `--no-log-to-console`
- **ADDED** `--log-file-path` option, default is no log file output, add path to json formatted log file
- **ADDED** `--log-coloring` option, enables colored logging output in console, default is non-colored
- **ADDED** `--log-console-timestamp` option, enabled timestamps in the console log, default is not to include time stamp
- **CHANGED** Stats output is not printed to StdOut and with formatted logging to log file if enabled
- **CHANGED** All logging now goes through logrus with the default logrus text formatting
- **CHANGED** Progress output in console now goes to StdOut instead of StdErr

Closes #220