### PR TITLE
Ensure execute permission is set for releases.

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -83,6 +83,11 @@ jobs:
         name: dist-win32-x64
         path: dist-win32-x64
 
+    - name: Set execute permission
+      run: |
+        chmod +x dist-linux-x64/longtail
+        chmod +x dist-macos-x64/longtail
+
     - name: Rename artifacts
       run: |
         cp dist-linux-x64/longtail longtail-linux-x64


### PR DESCRIPTION
- Noticed as a result of switching from Bazel's [`http_file`](https://bazel.build/rules/lib/repo/http#http_file) to [`http_archive`](https://bazel.build/rules/lib/repo/http#http_archive) that the execute permission wasn't set for archived binaries.