### PR TITLE
fix writing put target path without folder prefix writes to current folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - **FIXED** Corrected some function names logging
 - **FIXED** splitURI handles mixed forward and backward slash better
 - **FIXED** Reduced memory consumption when doing downsync/get of version
+- **FIXED** `put` with `--target-path` without folder in path (local or absolute) now writes to current folder instead of root
 - **UPDATED** Updated longtail to 0.3.6
 
 ## v0.3.5

--- a/commands/cmd_put.go
+++ b/commands/cmd_put.go
@@ -60,7 +60,7 @@ func put(
 	timeStats := []longtailutils.TimeStat{}
 
 	targetName := targetPath
-	parentPath := ""
+	parentPath := "."
 	pathDelimiter := strings.LastIndexAny(targetPath, "\\/")
 	if pathDelimiter != -1 {
 		parentPath = targetPath[0:pathDelimiter]

--- a/longtailutils/longtailutils.go
+++ b/longtailutils/longtailutils.go
@@ -301,7 +301,12 @@ func splitURI(uri string) (string, string) {
 	if i == -1 {
 		return "", uri
 	}
-	return uri[:i], uri[i+1:]
+	parent := uri[:i]
+	name := uri[i+1:]
+	if parent == "" && (uri[0] == '\\' || uri[0] == '/') {
+		parent = "/"
+	}
+	return parent, name
 }
 
 // ReadFromURI ...


### PR DESCRIPTION
- **FIXED** `put` with `--target-path` without folder in path (local or absolute) now writes to current folder instead of root

Closes #225 