### PR TITLE
Migrate to unsafe.Slice (added in Golang 1.17).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ##
+- **CHANGED** Migrated to `unsafe.Slice` for buffer to slice conversions.
+
+## v0.3.6
 - **CHANGED** commands now logs input details at `info` level
 - **CHANGED** Improved logging in remotestore with `info` level
 - **CHANGED** Stats output is now printed to StdOut and with formatted logging to log file if `--log-file-path` is enabled

--- a/longtaillib/longtaillib_test.go
+++ b/longtaillib/longtaillib_test.go
@@ -679,7 +679,7 @@ func TestPutGetStoredBlock(t *testing.T) {
 
 	stats, err := blockStoreProxy.GetStats()
 	if err != nil {
-		t.Errorf("TestPutGetStoredBlock() GetStats() %wd", err)
+		t.Errorf("TestPutGetStoredBlock() GetStats() %v", err)
 	}
 	if stats.StatU64[Longtail_BlockStoreAPI_StatU64_GetStoredBlock_Count] != 1 {
 		t.Errorf("TestPutGetStoredBlock() stats.BlocksGetCount %d != %d", stats.StatU64[Longtail_BlockStoreAPI_StatU64_GetStoredBlock_Count], 1)


### PR DESCRIPTION
- Migrate to [`unsafe.Slice`](https://pkg.go.dev/unsafe#Slice) which was [added in Golang 1.17](https://github.com/golang/go/issues/19367).
  - [Type-unsafe Pointers](https://go101.org/article/unsafe.html)
  - `reflect.SliceHeader` was also [deprecated (and then reverted)](https://github.com/golang/go/issues/53003) since it's considered undefined compiler behaviour.
- The rationale for this change was that the usage of `1 << 30` prevented slices greater than 1024MB. See log:
```
level=info msg="read store index" blobClient="gs://builds/server/Linux-x86_64/stores/longtail3/" bytes=1073585116 fname=tryAddRemoteStoreIndexWithLocking path="gs://builds/server/Linux-x86_64/stores/longtail3//server/Linux-x86_64/stores/longtail3/store.lsi"
panic: runtime error: slice bounds out of range [:1073783048] with length 1073741824

goroutine 57 [running]:
github.com/DanEngelbrecht/golongtail/longtaillib.(*NativeBuffer).ToBuffer(...)
	/home/runner/work/golongtail/golongtail/longtaillib/longtaillib.go:417
github.com/DanEngelbrecht/golongtail/remotestore.tryAddRemoteStoreIndexWithLocking({0xc0003f35e0, 0xc0005db4d0}, {0xc0005db4c0}, {0x12c9f38, 0xc00025a570})
	/home/runner/work/golongtail/golongtail/remotestore/remotestore.go:1179 +0x117c
github.com/DanEngelbrecht/golongtail/remotestore.tryAddRemoteStoreIndex({0x12c3788, 0xc0000400b0}, {0xc0005db6b8}, {0x12c9f38, 0xc00025a570})
	/home/runner/work/golongtail/golongtail/remotestore/remotestore.go:1286 +0x429
github.com/DanEngelbrecht/golongtail/remotestore.addToRemoteStoreIndex({0x12c3788, 0xc0000400b0}, {0x12c9f38, 0xc00025a570}, {0x0})
	/home/runner/work/golongtail/golongtail/remotestore/remotestore.go:1326 +0x239
github.com/DanEngelbrecht/golongtail/remotestore.addBlocksToRemoteStoreIndex({0x12c3788, 0xc0000400b0}, 0xc00023c480, {0x12c9f38, 0xc00025a570}, {0xc000e28e00, 0x23, 0x40})
	/home/runner/work/golongtail/golongtail/remotestore/remotestore.go:596 +0x385
github.com/DanEngelbrecht/golongtail/remotestore.contentIndexWorker({0x12c3788, 0xc0000400b0}, 0xc00023c480, {0x0, 0x0}, 0xc0001142a0, 0xc000260000, 0xc000114300, 0xc000114360, 0xc0001143c0, ...)
	/home/runner/work/golongtail/golongtail/remotestore/remotestore.go:866 +0x1245
github.com/DanEngelbrecht/golongtail/remotestore.NewRemoteBlockStore.func1()
	/home/runner/work/golongtail/golongtail/remotestore/remotestore.go:1011 +0x85
created by github.com/DanEngelbrecht/golongtail/remotestore.NewRemoteBlockStore
	/home/runner/work/golongtail/golongtail/remotestore/remotestore.go:1010 +0x84
```
