### PR TITLE
Only rebuild remote index from blocks with "Init" access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ##
+- **CHANGED** Only `init` operation will try to rebuild the store index from blocks
 - **UPDATED** All golang module dependencies updated
 
 ## v0.3.6


### PR DESCRIPTION
- **CHANGED** Only `init` operation will try to rebuild the store index from blocks
