### PR TITLE
fix error handling on failing to read store index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ##
 - **CHANGED** Only `init` operation will try to rebuild the store index from blocks
 - **ADDED** Added retry logic when reading remote store index
+- **FIXED** Don't do fatal exit if reading store index fails, just report error back to caller and log error at exit
+- **FIXED** Gracefully handle missing store.lsi condition as separate from failing to read existing store index
 - **UPDATED** All golang module dependencies updated
 
 ## v0.3.6

--- a/commands/cmd_upsync_test.go
+++ b/commands/cmd_upsync_test.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"io/ioutil"
+	"os"
 	"testing"
 )
 
@@ -39,6 +40,27 @@ func TestUpsyncWithLSI(t *testing.T) {
 	cmd, err = executeCommandLine("upsync", "--source-path", testPath+"/version/v3", "--target-path", fsBlobPathPrefix+"/index/v3.lvi", "--storage-uri", fsBlobPathPrefix+"/storage", "--version-local-store-index-path", fsBlobPathPrefix+"/index/v3.lsi")
 	if err != nil {
 		t.Errorf("%s: %s", cmd, err)
+	}
+}
+
+func TestUpsyncWithBrokenLSI(t *testing.T) {
+	testPath, _ := ioutil.TempDir("", "test")
+	fsBlobPathPrefix := "fsblob://" + testPath
+	createVersionData(t, fsBlobPathPrefix)
+
+	data := [11]uint8{8, 21, 141, 3, 1, 4, 124, 213, 1, 23, 123}
+	err := os.MkdirAll(fsBlobPathPrefix[9:]+"/storage", 0777)
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+	err = ioutil.WriteFile(fsBlobPathPrefix[9:]+"/storage/store.lsi", data[:11], 0644)
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+
+	cmd, err := executeCommandLine("upsync", "--source-path", testPath+"/version/v1", "--target-path", fsBlobPathPrefix+"/index/v1.lvi", "--storage-uri", fsBlobPathPrefix+"/storage", "--version-local-store-index-path", fsBlobPathPrefix+"/index/v1.lsi")
+	if err == nil {
+		t.Errorf("%s", cmd)
 	}
 }
 

--- a/longtailutils/longtailutils.go
+++ b/longtailutils/longtailutils.go
@@ -421,7 +421,7 @@ func ReadBlobWithRetry(
 		return nil, retryCount, errors.Wrap(err, fname)
 	}
 	if !exists {
-		err = errors.Wrap(longtaillib.NotExistErr(), fmt.Sprintf("%s does not exist", key))
+		err = errors.Wrap(longtaillib.NotExistErr(), fmt.Sprintf("%s/%s does not exist", client.String(), key))
 		return nil, retryCount, errors.Wrap(err, fname)
 	}
 	retryDelay := []time.Duration{0, 100 * time.Millisecond, 250 * time.Millisecond, 500 * time.Millisecond, 1 * time.Second, 2 * time.Second}

--- a/remotestore/remotestore_test.go
+++ b/remotestore/remotestore_test.go
@@ -958,23 +958,3 @@ func TestFSStoreIndexSyncWithoutLocking(t *testing.T) {
 
 	testStoreIndexSync(blobStore, t)
 }
-
-func TestNewIndexStrategy(t *testing.T) {
-	Longtail_HashAPI hashapi = longtaillib.CreateBlake3HashAPI()
-		//	storePath, err := ioutil.TempDir("", "test")
-	//	if err != nil {
-	//		t.Errorf("ioutil.TempDir() err == %s", err)
-	//	}
-	var blocks []longtaillib.Longtail_StoredBlock
-	for n := 0; n < 16; n++ {
-		storedBlock, err := generateStoredBlock(t, uint8(n+1))
-		if err != nil {
-			t.Errorf("longtailstorelib.NewFSBlobStore() err == %s", err)
-		}
-		blocks = append(blocks, storedBlock)
-	}
-	if len(blocks) != 16 {
-		t.Errorf("Bad panda")
-	}
-
-}

--- a/remotestore/remotestore_test.go
+++ b/remotestore/remotestore_test.go
@@ -958,3 +958,23 @@ func TestFSStoreIndexSyncWithoutLocking(t *testing.T) {
 
 	testStoreIndexSync(blobStore, t)
 }
+
+func TestNewIndexStrategy(t *testing.T) {
+	Longtail_HashAPI hashapi = longtaillib.CreateBlake3HashAPI()
+		//	storePath, err := ioutil.TempDir("", "test")
+	//	if err != nil {
+	//		t.Errorf("ioutil.TempDir() err == %s", err)
+	//	}
+	var blocks []longtaillib.Longtail_StoredBlock
+	for n := 0; n < 16; n++ {
+		storedBlock, err := generateStoredBlock(t, uint8(n+1))
+		if err != nil {
+			t.Errorf("longtailstorelib.NewFSBlobStore() err == %s", err)
+		}
+		blocks = append(blocks, storedBlock)
+	}
+	if len(blocks) != 16 {
+		t.Errorf("Bad panda")
+	}
+
+}


### PR DESCRIPTION
- **FIXED** Don't do fatal exit if reading store index fails, just report error back to caller and log error at exit
- **FIXED** Gracefully handle missing store.lsi condition as separate from failing to read existing store index
