### PR TITLE
Networks share paths that starts with \\ no longer need to be manually escaped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ##
+- **FIXED** Networks share paths that starts with \\ no longer need to be manually escaped (fixes https://github.com/DanEngelbrecht/golongtail/issues/249)
 - **UPDATED** Update to golang 1.21
 - **UPDATED** Update longtaillib to v0.4.1
 - **UPDATED** Updated all golang dependencies

--- a/longtailstorelib/fsstore.go
+++ b/longtailstorelib/fsstore.go
@@ -31,11 +31,16 @@ type fsBlobObject struct {
 }
 
 const UNCPrefix = "\\\\?\\"
+const NetworkPrefix = "\\"
 
 func NormalizeFileSystemPath(path string) string {
 	if strings.HasPrefix(path, UNCPrefix) {
 		forwardSlashReplaced := strings.Replace(path, "/", "\\", -1)
 		doubleBackwardRemoved := UNCPrefix + strings.Replace(forwardSlashReplaced[len(UNCPrefix):], "\\\\", "\\", -1)
+		return doubleBackwardRemoved
+	} else if strings.HasPrefix(path, NetworkPrefix) {
+		forwardSlashReplaced := strings.Replace(path, "/", "\\", -1)
+		doubleBackwardRemoved := NetworkPrefix + strings.Replace(forwardSlashReplaced[len(NetworkPrefix):], "\\\\", "\\", -1)
 		return doubleBackwardRemoved
 	}
 	backwardRemoved := strings.Replace(path, "\\", "/", -1)


### PR DESCRIPTION
- **FIXED** Networks share paths that starts with \\ no longer need to be manually escaped (fixes https://github.com/DanEngelbrecht/golongtail/issues/249)
