### PR TITLE
Issue #252 network paths with space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 ##
+- **CHANGED** For multi-source downsync/get the separator for paths is changed to | to avoid problems with path that contains spaces
+- **CHANGED** Made multi-path options separate from single-path
+  -- `--source-path` vs `--source-paths`
+  -- `--version-local-store-index-path` vs `--version-local-store-index-paths`
+- **FIXED** Network paths with spaces in them don't work - #252
+
+## v0.4.2
 - **FIXED** Networks share paths that starts with \\ no longer need to be manually escaped (fixes https://github.com/DanEngelbrecht/golongtail/issues/249)
 - **UPDATED** Update longtaillib to v0.4.2
 

--- a/commands/cmd_downsync_test.go
+++ b/commands/cmd_downsync_test.go
@@ -316,7 +316,7 @@ func TestMultiVersionDownsync(t *testing.T) {
 	executeCommandLine("upsync", "--include-filter-regex", ".*/$**.*\\.layer2$", "--source-path", testPath+"/source", "--target-path", fsBlobPathPrefix+"/index/layer2.lvi", "--storage-uri", fsBlobPathPrefix+"/storage", "--version-local-store-index-path", fsBlobPathPrefix+"/index/layer2.lsi")
 	executeCommandLine("upsync", "--include-filter-regex", ".*/$**.*\\.layer3$", "--source-path", testPath+"/source", "--target-path", fsBlobPathPrefix+"/index/layer3.lvi", "--storage-uri", fsBlobPathPrefix+"/storage", "--version-local-store-index-path", fsBlobPathPrefix+"/index/layer3.lsi")
 
-	cmd, err := executeCommandLine("downsync", "--source-path", fsBlobPathPrefix+"/index/base.lvi "+fsBlobPathPrefix+"/index/layer2.lvi "+fsBlobPathPrefix+"/index/layer3.lvi", "--target-path", testPath+"/target", "--storage-uri", fsBlobPathPrefix+"/storage", "--version-local-store-index-path", fsBlobPathPrefix+"/index/base.lsi "+fsBlobPathPrefix+"/index/layer2.lsi "+fsBlobPathPrefix+"/index/layer3.lsi")
+	cmd, err := executeCommandLine("downsync", "--source-paths", fsBlobPathPrefix+"/index/base.lvi|"+fsBlobPathPrefix+"/index/layer2.lvi|"+fsBlobPathPrefix+"/index/layer3.lvi", "--target-path", testPath+"/target", "--storage-uri", fsBlobPathPrefix+"/storage", "--version-local-store-index-path", fsBlobPathPrefix+"/index/base.lsi|"+fsBlobPathPrefix+"/index/layer2.lsi|"+fsBlobPathPrefix+"/index/layer3.lsi")
 	if err != nil {
 		t.Errorf("%s: %s", cmd, err)
 	}

--- a/commands/cmd_get.go
+++ b/commands/cmd_get.go
@@ -13,6 +13,7 @@ import (
 
 func get(
 	numWorkerCount int,
+	getConfigPath string,
 	getConfigPaths []string,
 	s3EndpointResolverURI string,
 	targetFolderPath string,
@@ -30,6 +31,7 @@ func get(
 	log := logrus.WithFields(logrus.Fields{
 		"fname":                 fname,
 		"numWorkerCount":        numWorkerCount,
+		"getConfigPath":         getConfigPath,
 		"getConfigPaths":        getConfigPaths,
 		"s3EndpointResolverURI": s3EndpointResolverURI,
 		"targetFolderPath":      targetFolderPath,
@@ -50,6 +52,10 @@ func get(
 	timeStats := []longtailutils.TimeStat{}
 
 	readGetConfigStartTime := time.Now()
+
+	if getConfigPath != "" {
+		getConfigPaths = []string{getConfigPath}
+	}
 
 	if len(getConfigPaths) < 1 {
 		err := fmt.Errorf("source-path is missing")
@@ -109,12 +115,14 @@ func get(
 		numWorkerCount,
 		blobStoreURI,
 		s3EndpointResolverURI,
+		"",
 		sourceFilePaths,
 		targetFolderPath,
 		targetIndexPath,
 		localCachePath,
 		retainPermissions,
 		validate,
+		"",
 		versionLocalStoreIndexPaths,
 		includeFilterRegEx,
 		excludeFilterRegEx,
@@ -130,7 +138,8 @@ func get(
 }
 
 type GetCmd struct {
-	GetConfigURIs []string `name:"source-path" help:"File uri(s) for json formatted get-config file" required:"" sep:" "`
+	GetConfigURI  string   `name:"source-path" help:"File uri(s) for json formatted get-config file" xor:"source-path,source-paths" required:""`
+	GetConfigURIs []string `name:"source-paths" help:"File uri(s) for json formatted get-config file" xor:"source-path,source-paths" required:"" sep:"|"`
 	S3EndpointResolverURLOption
 	TargetPathOption
 	TargetIndexUriOption
@@ -149,6 +158,7 @@ type GetCmd struct {
 func (r *GetCmd) Run(ctx *Context) error {
 	storeStats, timeStats, err := get(
 		ctx.NumWorkerCount,
+		r.GetConfigURI,
 		r.GetConfigURIs,
 		r.S3EndpointResolverURL,
 		r.TargetPath,

--- a/commands/cmd_get_test.go
+++ b/commands/cmd_get_test.go
@@ -115,7 +115,7 @@ func TestMultiVersionGet(t *testing.T) {
 	executeCommandLine("put", "--include-filter-regex", ".*/$**.*\\.layer2$", "--source-path", testPath+"/source", "--target-path", fsBlobPathPrefix+"/index/layer2.json", "--storage-uri", fsBlobPathPrefix+"/storage", "--version-local-store-index-path", fsBlobPathPrefix+"/index/layer2.lsi")
 	executeCommandLine("put", "--include-filter-regex", ".*/$**.*\\.layer3$", "--source-path", testPath+"/source", "--target-path", fsBlobPathPrefix+"/index/layer3.json", "--storage-uri", fsBlobPathPrefix+"/storage", "--version-local-store-index-path", fsBlobPathPrefix+"/index/layer3.lsi")
 
-	cmd, err := executeCommandLine("get", "--source-path", fsBlobPathPrefix+"/index/base.json "+fsBlobPathPrefix+"/index/layer2.json "+fsBlobPathPrefix+"/index/layer3.json", "--target-path", testPath+"/target")
+	cmd, err := executeCommandLine("get", "--source-paths", fsBlobPathPrefix+"/index/base.json|"+fsBlobPathPrefix+"/index/layer2.json|"+fsBlobPathPrefix+"/index/layer3.json", "--target-path", testPath+"/target")
 	if err != nil {
 		t.Errorf("%s: %s", cmd, err)
 	}
@@ -130,7 +130,7 @@ func TestMultiVersionGetMismatchStoreURI(t *testing.T) {
 	executeCommandLine("put", "--include-filter-regex", ".*/$**.*\\.layer2$", "--source-path", testPath+"/source", "--target-path", fsBlobPathPrefix+"/index/layer2.json", "--storage-uri", fsBlobPathPrefix+"/storage", "--version-local-store-index-path", fsBlobPathPrefix+"/index/layer2.lsi")
 	executeCommandLine("put", "--include-filter-regex", ".*/$**.*\\.layer3$", "--source-path", testPath+"/source", "--target-path", fsBlobPathPrefix+"/index/layer3.json", "--storage-uri", fsBlobPathPrefix+"/bad_storage", "--version-local-store-index-path", fsBlobPathPrefix+"/index/layer3.lsi")
 
-	cmd, err := executeCommandLine("get", "--source-path", fsBlobPathPrefix+"/index/base.json "+fsBlobPathPrefix+"/index/layer2.json "+fsBlobPathPrefix+"/index/layer3.json", "--target-path", testPath+"/target")
+	cmd, err := executeCommandLine("get", "--source-paths", fsBlobPathPrefix+"/index/base.json|"+fsBlobPathPrefix+"/index/layer2.json|"+fsBlobPathPrefix+"/index/layer3.json", "--target-path", testPath+"/target")
 	if err == nil {
 		t.Errorf("%s: %s", cmd, err)
 	}

--- a/commands/options.go
+++ b/commands/options.go
@@ -33,11 +33,11 @@ type TargetPathExcludeRegExOption struct {
 }
 
 type StorageURIOption struct {
-	StorageURI string `name:"storage-uri" help"Storage URI (local file system, GCS and S3 bucket URI supported)" required:""`
+	StorageURI string `name:"storage-uri" help:"Storage URI (local file system, GCS and S3 bucket URI supported)" required:""`
 }
 
 type S3EndpointResolverURLOption struct {
-	S3EndpointResolverURL string `name:"s3-endpoint-resolver-uri" help"Optional URI for S3 endpoint resolver"`
+	S3EndpointResolverURL string `name:"s3-endpoint-resolver-uri" help:"Optional URI for S3 endpoint resolver"`
 }
 
 type CachePathOption struct {
@@ -57,11 +57,11 @@ type TargetIndexUriOption struct {
 }
 
 type SourceUriOption struct {
-	SourcePath string `name:"source-path" help:"Source file uri" required:""`
+	SourcePath string `name:"source-path" help:"Source file uri" xor:"source-path,source-paths" required:""`
 }
 
 type MultiSourceUrisOption struct {
-	SourcePaths []string `name:"source-path" help:"Source file uri(s)" required:"" sep:" "`
+	SourcePaths []string `name:"source-paths" help:"Source file uri(s)" xor:"source-path,source-paths" required:"" sep:"|"`
 }
 
 type ValidateTargetOption struct {
@@ -69,11 +69,11 @@ type ValidateTargetOption struct {
 }
 
 type VersionLocalStoreIndexPathOption struct {
-	VersionLocalStoreIndexPath string `name:"version-local-store-index-path" help:"Path to an optimized store index for this particular version. If the file cant be read it will fall back to the master store index"`
+	VersionLocalStoreIndexPath string `name:"version-local-store-index-path" help:"Path to an optimized store index for this particular version. If the file cant be read it will fall back to the master store index" xor:"version-local-store-index-path,version-local-store-index-paths"`
 }
 
 type MultiVersionLocalStoreIndexPathsOption struct {
-	VersionLocalStoreIndexPaths []string `name:"version-local-store-index-path" help:"Path(s) to an optimized store index matching the source. If any of the file(s) cant be read it will fall back to the master store index" sep:" "`
+	VersionLocalStoreIndexPaths []string `name:"version-local-store-index-paths" help:"Path(s) to an optimized store index matching the source. If any of the file(s) cant be read it will fall back to the master store index" xor:"version-local-store-index-path,version-local-store-index-paths" sep:"|"`
 }
 
 type VersionIndexPathOption struct {


### PR DESCRIPTION
- **CHANGED** For multi-source downsync/get the separator for paths is changed to , (comma) to avoid problems with path that contains spaces.
- **FIXED** Network paths with spaces in them don't work - Fixes #252