### PR TITLE
fix(s3): use HeadObject for checking if blob exists

### DIFF
--- a/longtailstorelib/s3Store.go
+++ b/longtailstorelib/s3Store.go
@@ -144,14 +144,14 @@ func (blobObject *s3BlobObject) LockWriteVersion() (bool, error) {
 
 func (blobObject *s3BlobObject) Exists() (bool, error) {
 	const fname = "s3BlobObject.Exists()"
-	input := &s3.GetObjectAclInput{
+	input := &s3.HeadObjectInput{
 		Bucket: aws.String(blobObject.client.store.bucketName),
 		Key:    aws.String(blobObject.path),
 	}
-	_, err := blobObject.client.client.GetObjectAcl(blobObject.client.ctx, input)
+	_, err := blobObject.client.client.HeadObject(blobObject.client.ctx, input)
 	if err != nil {
-		var nsk *types.NoSuchKey
-		if errors.As(err, &nsk) {
+		var notFoundErr *types.NotFound
+		if errors.As(err, &notFoundErr) {
 			return false, nil
 		}
 		return false, errors.Wrap(err, fname)


### PR DESCRIPTION
Hi!
I'm evaluating Cloudflare's [R2](https://developers.cloudflare.com/r2/) buckets for blob storage with longtail. R2 is S3 compatible to a certain degree. Object Acl's is for example not (yet?) [implemented](https://developers.cloudflare.com/r2/api/s3/api/).

```sh
Indexing version           100%: |██████████████████████████████████████████████████|: [0s]
Writing content blocks     100%: |██████████████████████████████████████████████████|: [0s]
WARN Error from tryAddRemoteStoreIndex tryAddRemoteStoreIndex: tryWriteRemoteStoreIndex: s3BlobObject.Exists(): operation error S3: GetObjectAcl, https response error StatusCode: 501, RequestID: , HostID: , api error NotImplemented: GetObjectAcl not implemented  blobClient="s3://bkt-weur-builds-g000/store/" fname=addToRemoteStoreIndex
WARN Error from tryAddRemoteStoreIndex tryAddRemoteStoreIndex: tryWriteRemoteStoreIndex: s3BlobObject.Exists(): operation error S3: GetObjectAcl, https response error StatusCode: 501, RequestID: , HostID: , api error NotImplemented: GetObjectAcl not implemented  blobClient="s3://bkt-weur-builds-g000/store/" fname=addToRemoteStoreIndex
ERRO Failed updating remote store after 3 tryAddRemoteStoreIndex: tryAddRemoteStoreIndex: tryWriteRemoteStoreIndex: s3BlobObject.Exists(): operation error S3: GetObjectAcl, https response error StatusCode: 501, RequestID: , HostID: , api error NotImplemented: GetObjectAcl not implemented  blobClient="s3://bkt-weur-builds-g000/store/" fname=addToRemoteStoreIndex
ERRO Flush failed                                  error="StoreFlush.Wait: StoreFlush.Wait() failed: AsyncFlushAPIProxy_OnComplete: 5: I/O error." fname=StoreFlush.Wait
WARN Error from tryAddRemoteStoreIndex tryAddRemoteStoreIndex: tryWriteRemoteStoreIndex: s3BlobObject.Exists(): operation error S3: GetObjectAcl, https response error StatusCode: 501, RequestID: , HostID: , api error NotImplemented: GetObjectAcl not implemented  blobClient="s3://bkt-weur-builds-g000/store/" fname=addToRemoteStoreIndex
WARN Error from tryAddRemoteStoreIndex tryAddRemoteStoreIndex: tryWriteRemoteStoreIndex: s3BlobObject.Exists(): operation error S3: GetObjectAcl, https response error StatusCode: 501, RequestID: , HostID: , api error NotImplemented: GetObjectAcl not implemented  blobClient="s3://bkt-weur-builds-g000/store/" fname=addToRemoteStoreIndex
ERRO Failed updating remote store after 3 tryAddRemoteStoreIndex: tryAddRemoteStoreIndex: tryWriteRemoteStoreIndex: s3BlobObject.Exists(): operation error S3: GetObjectAcl, https response error StatusCode: 501, RequestID: , HostID: , api error NotImplemented: GetObjectAcl not implemented  blobClient="s3://bkt-weur-builds-g000/store/" fname=addToRemoteStoreIndex
ERRO NewRemoteBlockStore: contentIndexWorker: addToRemoteStoreIndex: tryAddRemoteStoreIndex: tryWriteRemoteStoreIndex: s3BlobObject.Exists(): operation error S3: GetObjectAcl, https response error StatusCode: 501, RequestID: , HostID: , api error NotImplemented: GetObjectAcl not implemented
FATA upsync: FlushStoresSync: StoreFlush.Wait: StoreFlush.Wait: StoreFlush.Wait() failed: AsyncFlushAPIProxy_OnComplete: 5: I/O error.
```

This PR suggests using `HeadObject()` instead of `GetObjectAcl()` for checking if an object exists, which makes golongtail compatible with Cloudflare R2 buckets.
Tested `upsync` and `downsync` successfully.