### PR TITLE
ci: Bump deprecated ubuntu-20.04 to ubuntu-22.04.

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -12,10 +12,10 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         arch: [amd64, arm64]
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             target: "./cmd/longtail/longtail"
             platform: linux
             tag: "${GITHUB_REF_NAME}"
@@ -28,7 +28,7 @@ jobs:
             platform: win32
             tag: "${env:GITHUB_REF_NAME}"
         exclude:
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             arch: arm64
           - os: windows-latest
             arch: arm64
@@ -68,7 +68,7 @@ jobs:
 
   create-release:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     needs: [build]
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -12,10 +12,10 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-22.04, macos-latest, windows-latest]
         arch: [amd64, arm64]
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             target: "./cmd/longtail/longtail"
             platform: linux
             tag: "${GITHUB_REF_NAME}"
@@ -28,7 +28,7 @@ jobs:
             platform: win32
             tag: "${env:GITHUB_REF_NAME}"
         exclude:
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             arch: arm64
           - os: windows-latest
             arch: arm64
@@ -68,7 +68,7 @@ jobs:
 
   create-release:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     needs: [build]
 

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         arch: [amd64]
         include:
           - os: macos-latest

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-22.04, macos-latest, windows-latest]
         arch: [amd64]
         include:
           - os: macos-latest

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   cancel-old-build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Cancel Previous Runs
       uses: styfle/cancel-workflow-action@0.12.1
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-22.04, macos-latest, windows-latest]
         arch: [amd64]
         include:
           - os: macos-latest

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         arch: [amd64]
         include:
           - os: macos-latest


### PR DESCRIPTION
- Resolve the following occurring on [new PRs](https://github.com/DanEngelbrecht/golongtail/pull/263): `This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101`